### PR TITLE
Allow test_case to use inconclusive as keyword; Add panics and matches to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First of all you have to add this dependency to your `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
-test-case = "0.3.3"
+test-case = "1.0.0-alpha-1"
 ```
 
 Additionally you have to import the procedural macro with `use` statement:
@@ -177,14 +177,10 @@ mod parses_input {
 If test expectation is preceded by `matches` keyword, the result will be tested whether it fits within provided pattern.
 
 ```rust
-fn zip(left: &str, right: &str) -> (&str, &str) {
+#[test_case("foo", "bar" => matches ("foo", _) ; "first element of zipped tuple is correct")]
+#[test_case("foo", "bar" => matches (_, "bar") ; "second element of zipped tuple is correct")]
+fn zip_test<'a>(left: &'a str, right: &'a str) -> (&'a str, &'a str) {
     (left, right)
-}
-
-#[test_case("foo", "bar" => matches ("foo", _) ; "first element of zipped tuple is correct"]
-#[test_case("foo", "bar" => matches (_, "bar") ; "second element of zipped tuple is correct"]
-fn zip_test(left: &str, right: &str) -> (&str, &str) {
-    zip(left, right)
 }
 ```
 
@@ -193,6 +189,7 @@ fn zip_test(left: &str, right: &str) -> (&str, &str) {
 If test case expectation is preceded by `panics` keyword and the expectation itself is `&str` **or** expresion that evaluates to `&str` then test case will be expected to panic during execution.
 
 ```rust
+
 #[test_case("foo" => panics "invalid input")]
 #[test_case("bar")]
 fn test_panicking(input: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! # Example usage:
 //!
-//! ```rust
+//! ```ignore
 //! #![cfg(test)]
 //! extern crate test_case;
 //!
@@ -174,14 +174,11 @@
 //! If test expectation is preceded by `matches` keyword, the result will be tested whether it fits within provided pattern.
 //!
 //! ```rust
-//! fn zip(left: &str, right: &str) -> (&str, &str) {
+//! # use test_case::test_case;
+//! #[test_case("foo", "bar" => matches ("foo", _) ; "first element of zipped tuple is correct")]
+//! #[test_case("foo", "bar" => matches (_, "bar") ; "second element of zipped tuple is correct")]
+//! fn zip_test<'a>(left: &'a str, right: &'a str) -> (&'a str, &'a str) {
 //!     (left, right)
-//! }
-//!
-//! #[test_case("foo", "bar" => matches ("foo", _) ; "first element of zipped tuple is correct"]
-//! #[test_case("foo", "bar" => matches (_, "bar") ; "second element of zipped tuple is correct"]
-//! fn zip_test(left: &str, right: &str) -> (&str, &str) {
-//!     zip(left, right)
 //! }
 //! ```
 //!
@@ -190,6 +187,8 @@
 //! If test case expectation is preceded by `panics` keyword and the expectation itself is `&str` **or** expresion that evaluates to `&str` then test case will be expected to panic during execution.
 //!
 //! ```rust
+//! # use test_case::test_case;
+//!
 //! #[test_case("foo" => panics "invalid input")]
 //! #[test_case("bar")]
 //! fn test_panicking(input: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! test-case = "0.3.3"
+//! test-case = "1.0.0-alpha-1"
 //! ```
 //!
 //! Additionally you have to import the procedural macro with `use` statement:
@@ -28,7 +28,7 @@
 //!
 //! use test_case::test_case;
 //!
-//! #[test_case( 2,  4 ; "when both operands are possitive")]
+//! #[test_case( 2,  4 ; "when both operands are positive")]
 //! #[test_case( 4,  2 ; "when operands are swapped")]
 //! #[test_case(-2, -4 ; "when both operands are negative")]
 //! fn multiplication_tests(x: i8, y: i8) {
@@ -44,7 +44,7 @@
 //! $ cargo test
 //!
 //! running 3 tests
-//! test multiplication_tests::when_both_operands_are_possitive ... ok
+//! test multiplication_tests::when_both_operands_are_positive ... ok
 //! test multiplication_tests::when_both_operands_are_negative ... ok
 //! test multiplication_tests::when_operands_are_swapped ... ok
 //!
@@ -136,10 +136,16 @@
 //!
 //! If test case name (passed using `;` syntax described above) contains word "inconclusive", generated test will be marked with `#[ignore]`.
 //!
+//! ### Keyword inconclusive (since 1.0.0)
+//!
+//! If test expectation is preceded by keyword `inconclusive` the test will be ignored as if it's description would contain word `inconclusive`
+//!
+//!
 //! ```rust
 //! # use test_case::test_case;
 //! #[test_case("42")]
 //! #[test_case("XX" ; "inconclusive - parsing letters temporarily doesn't work but it's ok")]
+//! #[test_case("na" => inconclusive ())]
 //! fn parses_input(input: &str) {
 //!     // ...
 //! }
@@ -163,7 +169,35 @@
 //!
 //! ```
 //!
-//! **Note**: word `inconclusive` is only reserved in test name given after `;`.
+//! ## Pattern matched test cases (since 1.0.0)
+//!
+//! If test expectation is preceded by `matches` keyword, the result will be tested whether it fits within provided pattern.
+//!
+//! ```rust
+//! fn zip(left: &str, right: &str) -> (&str, &str) {
+//!     (left, right)
+//! }
+//!
+//! #[test_case("foo", "bar" => matches ("foo", _) ; "first element of zipped tuple is correct"]
+//! #[test_case("foo", "bar" => matches (_, "bar") ; "second element of zipped tuple is correct"]
+//! fn zip_test(left: &str, right: &str) -> (&str, &str) {
+//!     zip(left, right)
+//! }
+//! ```
+//!
+//! ## Panicking test cases (since 1.0.0)
+//!
+//! If test case expectation is preceded by `panics` keyword and the expectation itself is `&str` **or** expresion that evaluates to `&str` then test case will be expected to panic during execution.
+//!
+//! ```rust
+//! #[test_case("foo" => panics "invalid input")]
+//! #[test_case("bar")]
+//! fn test_panicking(input: &str) {
+//!     if input == "foo" {
+//!         panic!("invalid input")
+//!     }
+//! }
+//! ```
 
 extern crate proc_macro;
 

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -16,6 +16,7 @@ pub struct TestCase {
 pub enum Expected {
     Pat(Pat),
     Panic(LitStr),
+    Ignored(Box<Expr>),
     Expr(Box<Expr>),
 }
 
@@ -30,6 +31,7 @@ impl ToString for Expected {
         match self {
             Expected::Pat(p) => format!("matches {}", fmt_syn(&p)),
             Expected::Panic(p) => format!("panics {}", fmt_syn(&p)),
+            Expected::Ignored(e) => format!("ignored {}", fmt_syn(&e)),
             Expected::Expr(e) => format!("expects {}", fmt_syn(&e)),
         }
     }
@@ -48,6 +50,12 @@ impl Parse for Expected {
             let _kw = input.parse::<kw::panics>()?;
             let pat = input.parse()?;
             return Ok(Expected::Panic(pat));
+        }
+
+        if lookahead.peek(kw::inconclusive) {
+            let _kw = input.parse::<kw::inconclusive>()?;
+            let expr = input.parse()?;
+            return Ok(Expected::Ignored(expr));
         }
 
         let expr = input.parse()?;
@@ -142,12 +150,17 @@ impl TestCase {
                 attrs.push(parse_quote! { #[should_panic(expected = #l)] });
                 parse_quote! {()}
             }
+            Some(Expected::Ignored(_)) => {
+                attrs.push(parse_quote! { #[ignore] });
+                parse_quote! {()}
+            }
             None => parse_quote! {()},
         };
 
         if inconclusive {
             attrs.push(parse_quote! { #[ignore] });
         }
+
         attrs.append(&mut item.attrs.clone());
 
         quote! {

--- a/tests/snapshots/acceptance__runs_all_tests.snap
+++ b/tests/snapshots/acceptance__runs_all_tests.snap
@@ -13,10 +13,10 @@ expression: lines
 
 running 0 tests
 running 0 tests
-running 42 tests
+running 45 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out
-test result: ok. 38 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
+test result: ok. 38 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok
 test test_cases::abs_tests::returns_opposite_number_for_non_positive_input ... ok
@@ -33,6 +33,9 @@ test test_cases::inconclusive_tests::this_test_is_also_inconclusive ... ignored
 test test_cases::inconclusive_tests::this_test_is_also_inconclusive_even_all_caps ... ignored
 test test_cases::inconclusive_tests::this_test_is_also_inconclusive_even_inverted_caps ... ignored
 test test_cases::inconclusive_tests::this_test_is_inconclusive_and_will_always_be ... ignored
+test test_cases::inconclusives::_ignored_ ... ignored
+test test_cases::inconclusives::inconclusive_test ... ignored
+test test_cases::inconclusives::test_is_not_ran ... ignored
 test test_cases::keyword_test::_true ... ok
 test test_cases::leading_underscore_in_test_name::_dummy_ ... ok
 test test_cases::lowercase_test_name::_dummy_code_ ... ok

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -166,4 +166,11 @@ mod test_cases {
     fn panicing(_: ()) {
         panic!("It has to panic")
     }
+
+    #[test_case(() => inconclusive ())]
+    #[test_case(() => inconclusive (); "test is not ran")]
+    #[test_case(() => inconclusive (); "inconclusive test")]
+    fn inconclusives(_: ()) {
+        unreachable!()
+    }
 }


### PR DESCRIPTION
Title says it all.
I've also fixed one typo
Fixes #30 and #20 (only adds the keyword, doesn't touch string `inconclusive` at all)