### PR TITLE
Refactor code, move some of the code generation into submodules

### DIFF
--- a/src/expected/expr_case.rs
+++ b/src/expected/expr_case.rs
@@ -1,0 +1,33 @@
+use crate::expected::Case;
+use crate::utils::fmt_syn;
+use std::fmt;
+use syn::parse_quote;
+use syn::{Attribute, Expr};
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct ExprCase {
+    value: Box<Expr>,
+}
+
+impl fmt::Display for ExprCase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "expects {}", fmt_syn(&self.value))
+    }
+}
+
+impl Case for ExprCase {
+    fn body(&self) -> Option<Expr> {
+        let value = &self.value;
+        Some(parse_quote! { assert_eq!(#value, _result) })
+    }
+
+    fn attr(&self) -> Option<Attribute> {
+        None
+    }
+}
+
+impl ExprCase {
+    pub fn new(value: Box<Expr>) -> Self {
+        Self { value }
+    }
+}

--- a/src/expected/ignore_case.rs
+++ b/src/expected/ignore_case.rs
@@ -1,0 +1,32 @@
+use crate::expected::Case;
+use crate::utils::fmt_syn;
+use std::fmt;
+use syn::parse_quote;
+use syn::{Attribute, Expr};
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct IgnoreCase {
+    value: Box<Expr>,
+}
+
+impl fmt::Display for IgnoreCase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ignored {}", fmt_syn(&self.value))
+    }
+}
+
+impl Case for IgnoreCase {
+    fn body(&self) -> Option<Expr> {
+        None
+    }
+
+    fn attr(&self) -> Option<Attribute> {
+        Some(parse_quote! { #[ignore] })
+    }
+}
+
+impl IgnoreCase {
+    pub fn new(value: Box<Expr>) -> Self {
+        Self { value }
+    }
+}

--- a/src/expected/mod.rs
+++ b/src/expected/mod.rs
@@ -1,0 +1,92 @@
+pub mod expr_case;
+pub mod ignore_case;
+pub mod panic_case;
+pub mod pattern_case;
+
+use crate::expected::expr_case::ExprCase;
+use crate::expected::ignore_case::IgnoreCase;
+use crate::expected::panic_case::PanicCase;
+use crate::expected::pattern_case::PatternCase;
+use std::fmt;
+use syn::parse::{Parse, ParseStream};
+use syn::{Attribute, Error, Expr, LitStr, Pat};
+
+mod kw {
+    syn::custom_keyword!(matches);
+    syn::custom_keyword!(panics);
+    syn::custom_keyword!(inconclusive);
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub enum Expected {
+    Pattern(PatternCase),
+    Panic(PanicCase),
+    Ignore(IgnoreCase),
+    Expr(ExprCase),
+}
+
+pub trait Case {
+    fn body(&self) -> Option<Expr>;
+    fn attr(&self) -> Option<Attribute>;
+}
+
+impl fmt::Display for Expected {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Expected::Pattern(v) => write!(f, "{}", v),
+            Expected::Panic(v) => write!(f, "{}", v),
+            Expected::Ignore(v) => write!(f, "{}", v),
+            Expected::Expr(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+impl Parse for Expected {
+    fn parse(input: ParseStream) -> Result<Self, Error> {
+        let lookahead = input.lookahead1();
+
+        if lookahead.peek(kw::matches) {
+            let _kw = input.parse::<kw::matches>()?;
+            return Ok(Expected::new_pattern(input.parse()?));
+        }
+
+        if lookahead.peek(kw::panics) {
+            let _kw = input.parse::<kw::panics>()?;
+            return Ok(Expected::new_panic(input.parse()?));
+        }
+
+        if lookahead.peek(kw::inconclusive) {
+            let _kw = input.parse::<kw::inconclusive>()?;
+            return Ok(Expected::new_ignore(input.parse()?));
+        }
+
+        Ok(Expected::new_expr(input.parse()?))
+    }
+}
+
+impl Expected {
+    pub fn new_pattern(pat: Pat) -> Self {
+        Expected::Pattern(PatternCase::new(pat))
+    }
+
+    pub fn new_panic(lit_str: LitStr) -> Self {
+        Expected::Panic(PanicCase::new(lit_str))
+    }
+
+    pub fn new_ignore(expr: Box<Expr>) -> Self {
+        Expected::Ignore(IgnoreCase::new(expr))
+    }
+
+    pub fn new_expr(expr: Box<Expr>) -> Self {
+        Expected::Expr(ExprCase::new(expr))
+    }
+
+    pub fn case(&self) -> &dyn Case {
+        match self {
+            Expected::Pattern(e) => e,
+            Expected::Panic(e) => e,
+            Expected::Ignore(e) => e,
+            Expected::Expr(e) => e,
+        }
+    }
+}

--- a/src/expected/panic_case.rs
+++ b/src/expected/panic_case.rs
@@ -1,0 +1,33 @@
+use crate::expected::Case;
+use crate::utils::fmt_syn;
+use std::fmt;
+use syn::parse_quote;
+use syn::{Attribute, Expr, LitStr};
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct PanicCase {
+    value: LitStr,
+}
+
+impl fmt::Display for PanicCase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "panics {}", fmt_syn(&self.value))
+    }
+}
+
+impl Case for PanicCase {
+    fn body(&self) -> Option<Expr> {
+        None
+    }
+
+    fn attr(&self) -> Option<Attribute> {
+        let value = &self.value;
+        Some(parse_quote! { #[should_panic(expected = #value)] })
+    }
+}
+
+impl PanicCase {
+    pub fn new(value: LitStr) -> Self {
+        Self { value }
+    }
+}

--- a/src/expected/pattern_case.rs
+++ b/src/expected/pattern_case.rs
@@ -1,0 +1,40 @@
+use crate::expected::Case;
+use crate::utils::fmt_syn;
+use quote::quote;
+use std::fmt;
+use syn::parse_quote;
+use syn::{Attribute, Expr, Pat};
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct PatternCase {
+    value: Pat,
+}
+
+impl fmt::Display for PatternCase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "matches {}", fmt_syn(&self.value))
+    }
+}
+
+impl Case for PatternCase {
+    fn body(&self) -> Option<Expr> {
+        let value = &self.value;
+        let pat_str = format!("{}", quote! { #value });
+        Some(parse_quote! {
+            match _result {
+                #value => (),
+                e => panic!("Expected {} found {:?}", #pat_str, e)
+            }
+        })
+    }
+
+    fn attr(&self) -> Option<Attribute> {
+        None
+    }
+}
+
+impl PatternCase {
+    pub fn new(value: Pat) -> Self {
+        Self { value }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,7 @@ use syn::parse_quote;
 use syn::spanned::Spanned;
 use test_case::TestCase;
 
+mod expected;
 mod test_case;
 mod utils;
 

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -1,8 +1,9 @@
+use crate::expected::Expected;
+use crate::utils::fmt_syn;
 use quote::quote;
-use quote::ToTokens;
 use syn::export::TokenStream2;
 use syn::parse::{Parse, ParseStream};
-use syn::{parse_quote, Error, Expr, Ident, ItemFn, LitStr, Pat, Token};
+use syn::{parse_quote, Error, Expr, Ident, ItemFn, LitStr, Token};
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct TestCase {
@@ -10,61 +11,6 @@ pub struct TestCase {
     args: Vec<Expr>,
     expected: Option<Expected>,
     case_desc: Option<LitStr>,
-}
-
-#[cfg_attr(test, derive(Debug, PartialEq))]
-pub enum Expected {
-    Pat(Pat),
-    Panic(LitStr),
-    Ignored(Box<Expr>),
-    Expr(Box<Expr>),
-}
-
-mod kw {
-    syn::custom_keyword!(matches);
-    syn::custom_keyword!(panics);
-    syn::custom_keyword!(inconclusive);
-}
-
-impl ToString for Expected {
-    fn to_string(&self) -> String {
-        match self {
-            Expected::Pat(p) => format!("matches {}", fmt_syn(&p)),
-            Expected::Panic(p) => format!("panics {}", fmt_syn(&p)),
-            Expected::Ignored(e) => format!("ignored {}", fmt_syn(&e)),
-            Expected::Expr(e) => format!("expects {}", fmt_syn(&e)),
-        }
-    }
-}
-
-impl Parse for Expected {
-    fn parse(input: ParseStream) -> Result<Self, Error> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(kw::matches) {
-            let _kw = input.parse::<kw::matches>()?;
-            let pat = input.parse()?;
-            return Ok(Expected::Pat(pat));
-        }
-
-        if lookahead.peek(kw::panics) {
-            let _kw = input.parse::<kw::panics>()?;
-            let pat = input.parse()?;
-            return Ok(Expected::Panic(pat));
-        }
-
-        if lookahead.peek(kw::inconclusive) {
-            let _kw = input.parse::<kw::inconclusive>()?;
-            let expr = input.parse()?;
-            return Ok(Expected::Ignored(expr));
-        }
-
-        let expr = input.parse()?;
-        Ok(Expected::Expr(expr))
-    }
-}
-
-fn fmt_syn(syn: &(impl ToTokens + Clone)) -> String {
-    syn.clone().into_token_stream().to_string()
 }
 
 impl Parse for TestCase {
@@ -133,32 +79,24 @@ impl TestCase {
 
         let mut attrs = vec![];
 
-        let expected: Expr = match &self.expected {
-            Some(Expected::Pat(pat)) => {
-                let pat_str = format!("{}", quote! { #pat });
-                parse_quote! {
-                    match _result {
-                        #pat => (),
-                        e => panic!("Expected {} found {:?}", #pat_str, e)
-                    }
-                }
+        let expected = if let Some(expected) = &self.expected {
+            let case = expected.case();
+
+            if let Some(attr) = case.attr() {
+                attrs.push(attr);
             }
-            Some(Expected::Expr(e)) => {
-                parse_quote! { assert_eq!(#e, _result) }
+
+            if let Some(body) = case.body() {
+                body
+            } else {
+                parse_quote! { () }
             }
-            Some(Expected::Panic(l)) => {
-                attrs.push(parse_quote! { #[should_panic(expected = #l)] });
-                parse_quote! {()}
-            }
-            Some(Expected::Ignored(_)) => {
-                attrs.push(parse_quote! { #[ignore] });
-                parse_quote! {()}
-            }
-            None => parse_quote! {()},
+        } else {
+            parse_quote! { () }
         };
 
         if inconclusive {
-            attrs.push(parse_quote! { #[ignore] });
+            attrs.push(parse_quote! { #[ignore] })
         }
 
         attrs.append(&mut item.attrs);
@@ -183,27 +121,47 @@ mod tests {
 
         mod parse {
             use super::*;
+            use crate::expected::expr_case::ExprCase;
+            use crate::expected::ignore_case::IgnoreCase;
+            use crate::expected::panic_case::PanicCase;
+            use crate::expected::pattern_case::PatternCase;
             use syn::parse_quote;
 
             #[test]
             fn parses_expression() {
                 let actual: Expected = parse_quote! { 2 + 3 };
 
-                assert_eq!(Expected::Expr(parse_quote!(2 + 3)), actual);
+                assert_eq!(Expected::Expr(ExprCase::new(parse_quote!(2 + 3))), actual);
             }
 
             #[test]
             fn parses_panic() {
                 let actual: Expected = parse_quote! { panics "Error msg" };
 
-                assert_eq!(Expected::Panic(parse_quote!("Error msg")), actual);
+                assert_eq!(
+                    Expected::Panic(PanicCase::new(parse_quote!("Error msg"))),
+                    actual
+                );
             }
 
             #[test]
             fn parses_pattern() {
                 let actual: Expected = parse_quote! { matches Some(_) };
 
-                assert_eq!(Expected::Pat(parse_quote!(Some(_))), actual);
+                assert_eq!(
+                    Expected::Pattern(PatternCase::new(parse_quote!(Some(_)))),
+                    actual
+                );
+            }
+
+            #[test]
+            fn parses_inconclusive() {
+                let actual: Expected = parse_quote! { inconclusive "Ignore this" };
+
+                assert_eq!(
+                    Expected::Ignore(IgnoreCase::new(parse_quote!("Ignore this"))),
+                    actual
+                );
             }
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use proc_macro2::{Ident, Span};
+use syn::export::ToTokens;
 
 pub fn escape_test_name(input: impl AsRef<str>) -> Ident {
     if input.as_ref().is_empty() {
@@ -26,7 +27,12 @@ pub fn escape_test_name(input: impl AsRef<str>) -> Ident {
     if !ident.starts_with(|c: char| c == '_' || c.is_ascii_alphabetic()) {
         ident = format!("_{}", ident);
     }
+
     Ident::new(&ident, Span::call_site())
+}
+
+pub fn fmt_syn(syn: &(impl ToTokens + Clone)) -> String {
+    syn.clone().into_token_stream().to_string()
 }
 
 #[cfg(test)]

--- a/tests/snapshots/acceptance__runs_all_tests.snap
+++ b/tests/snapshots/acceptance__runs_all_tests.snap
@@ -15,7 +15,7 @@ running 0 tests
 running 0 tests
 running 45 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out
 test result: ok. 38 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok


### PR DESCRIPTION
This is a just raw refactor.
Adding new macro types should be easy due to this.
I'm still thinking how to introduce `display /regex/` and `debug /regex/`. I thought I'd do them with `r#""#` raw string literals, but see no way to determine if input string is a raw string literal. Well... I'm gonna leave this here for now and work on features after I find out. 