### PR TITLE
Test using an older version of Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: rust
 rust:
   - nightly
   - stable
+  - 1.34.2


### PR DESCRIPTION
Test against a minimum supported version of Rust. For now, use
1.34.2 as thats is the oldest found in most current Linux
distributions at this time.