### PR TITLE
Fix syn version to 1.0.57

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro = true
 path       = "src/lib.rs"
 
 [dependencies]
-syn = { version = "1.0", features = ["full", "extra-traits"] }
+syn = { version = "1.0.57", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = { version = "1.0", features = [] }
 cfg-if = "1.0.0"


### PR DESCRIPTION
fix syn version to fix forrowing compile error
```
error[E0432]: unresolved import `syn::export`
 --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/test-case-0.3.3/src/test_case.rs:4:10
  |
4 | use syn::export::TokenStream2;
  |          ^^^^^^ could not find `export` in `syn`

```