### PR TITLE
Allow `test_case` attribute to be used qualified.

### DIFF
--- a/acceptance_tests/basic/src/lib.rs
+++ b/acceptance_tests/basic/src/lib.rs
@@ -178,4 +178,8 @@ mod test_cases {
     fn inconclusives(_: ()) {
         unreachable!()
     }
+
+    #[test_case::test_case(1; "first test")]
+    #[test_case::test_case(1; "second test")]
+    fn qualified_attribute(_: u8) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ pub fn test_case(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut test_cases = vec![test_case];
     let mut attrs_to_remove = vec![];
     for (idx, attr) in item.attrs.iter().enumerate() {
-        if attr.path == parse_quote!(test_case) {
+        if attr.path == parse_quote!(test_case) || attr.path == parse_quote!(test_case::test_case) {
             let test_case = match attr.parse_args::<TestCase>() {
                 Ok(test_case) => test_case,
                 Err(err) => {

--- a/tests/snapshots/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/acceptance__acceptance__basic.snap
@@ -4,9 +4,9 @@ expression: lines
 
 ---
 running 0 tests
-running 46 tests
+running 48 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 39 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
+test result: ok. 41 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok
 test test_cases::abs_tests::returns_opposite_number_for_non_positive_input ... ok
@@ -45,6 +45,8 @@ test test_cases::panicing::_panics_it_has_to_panic_ ... ok
 test test_cases::panics_without_value::_panics_ ... ok
 test test_cases::pattern_matching_result::_simpleenum_var2_matches_simpleenum_var2 ... ok
 test test_cases::pattern_matching_result_fails::_simpleenum_var1_matches_simpleenum_var2 ... ok
+test test_cases::qualified_attribute::first_test ... ok
+test test_cases::qualified_attribute::second_test ... ok
 test test_cases::result::_2_expects_4 ... ok
 test test_cases::result::_4_expects_8 ... ok
 test test_cases::result_and_name::_4_5_expects_9 ... ok


### PR DESCRIPTION
This allows it to be generated via macros, without needing to use the name in
call site scope.