### PR TITLE
Add `not`, `and` and `or` operators to complex test cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features -- -D warnings
+          args: --all-features --tests -- -D warnings
 
       - name: Fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - develop
 
 jobs:
   validate:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ version_check = "0.9"
 insta       = "1.8"
 itertools   = "0.10"
 lazy_static = "1.4"
+indexmap    = "=1.7" # insta dependency that has MSRV 1.49 on 1.8, so we manually keep it <1.8
 
 [[test]]
 name = "acceptance"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path       = "src/lib.rs"
 [dependencies]
 cfg-if           = "1.0"
 proc-macro2      = { version = "1.0", features = [] }
-proc-macro-error = "1.0.4"
+proc-macro-error = "1.0"
 quote            = "1.0"
 syn              = { version = "1.0", features = ["full", "extra-traits"] }
 

--- a/acceptance_tests/async/src/lib.rs
+++ b/acceptance_tests/async/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod test_cases {
     use test_case::test_case;
 

--- a/acceptance_tests/basic/src/lib.rs
+++ b/acceptance_tests/basic/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod test_cases {
     use test_case::test_case;
 
@@ -283,7 +284,21 @@ mod test_cases {
     #[test_case(1.0 => is gt 0.0 and lt 5.0)]
     #[test_case(1.0 => is gt 0.0 or lt 0.0)]
     #[test_case(-2.0 => is gt 0.0 or lt 0.0)]
+    #[test_case(-2.0 => is (gt 0.0 or lt 0.0) and lt -1.0)]
+    #[test_case(1.0 => is (gt 0.0 or lt -1.5) and lt 2.0)]
+    #[test_case(0.3 => is (gt 0.0 and lt 1.0) or gt 1.2)]
+    #[test_case(0.7 => is (gt 0.0 and lt 1.0) or gt 1.2)]
     fn combinators(v: f32) -> f32 {
         v * 2.0
+    }
+
+    #[test_case(vec![1, 2, 3] => it contains 1 and contains 2 and contains_in_order [2, 3])]
+    #[test_case(vec![1, 2, 3] => it contains 1 or contains 4)]
+    #[test_case(vec![1, 2, 3] => it (contains 1 or contains 4) and contains 2)]
+    #[test_case(vec![1, 2, 3] => it (contains 1 and contains 3) or contains 5)]
+    #[test_case(vec![1, 2, 3] => it (contains 6 and contains 7) or contains 1)]
+    #[test_case(vec![1, 2, 3] => it (contains 6 and contains 7) or (contains 1 and contains_in_order [1, 2, 3]))]
+    fn combinators_with_arrays(a: Vec<u8>) -> Vec<u8> {
+        a
     }
 }

--- a/acceptance_tests/basic/src/lib.rs
+++ b/acceptance_tests/basic/src/lib.rs
@@ -257,4 +257,23 @@ mod test_cases {
     fn contains_tests(items: Vec<u64>) -> Vec<u64> {
         items
     }
+
+    #[test_case(1.0 => is not eq 2.5)]
+    #[test_case(1.0 => is not almost 2.1 precision 0.01)]
+    #[test_case(1.0 => is not not eq 2.0)] // Yeah, that's legal
+    fn not_complex(input: f32) -> f32 { input * 1.0 }
+
+    #[test_case("Cargo.yaml".parse().unwrap() => is not existing_path)]
+    #[test_case("Cargo.toml".parse().unwrap() => is not dir)]
+    #[test_case("src/".parse().unwrap() => is not file)]
+    fn not_path(path: std::path::PathBuf) -> String {
+        path.to_string_lossy().to_string()
+    }
+
+    #[test_case(vec![1, 2, 3, 4] => it not contains 5)]
+    #[test_case(vec![1, 2, 3, 4] => it not contains_in_order [3, 2])]
+    fn not_contains_tests(items: Vec<u64>) -> Vec<u64> {
+        items
+    }
+
 }

--- a/acceptance_tests/basic/src/lib.rs
+++ b/acceptance_tests/basic/src/lib.rs
@@ -275,4 +275,9 @@ mod test_cases {
     fn not_contains_tests(items: Vec<u64>) -> Vec<u64> {
         items
     }
+
+    #[test_case(2.0 => it (eq 2.0))]
+    fn in_parens(_: f32) -> f32 {
+        2.0
+    }
 }

--- a/acceptance_tests/basic/src/lib.rs
+++ b/acceptance_tests/basic/src/lib.rs
@@ -260,7 +260,7 @@ mod test_cases {
 
     #[test_case(1.0 => is not eq 2.5)]
     #[test_case(1.0 => is not almost 2.1 precision 0.01)]
-    #[test_case(1.0 => is not not eq 2.0)] // Yeah, that's legal
+    #[test_case(1.0 => is not not not not lt 3.0)] // Yeah, that's legal
     fn not_complex(input: f32) -> f32 { input * 1.0 }
 
     #[test_case("Cargo.yaml".parse().unwrap() => is not existing_path)]
@@ -275,5 +275,4 @@ mod test_cases {
     fn not_contains_tests(items: Vec<u64>) -> Vec<u64> {
         items
     }
-
 }

--- a/acceptance_tests/basic/src/lib.rs
+++ b/acceptance_tests/basic/src/lib.rs
@@ -260,7 +260,6 @@ mod test_cases {
 
     #[test_case(1.0 => is not eq 2.5)]
     #[test_case(1.0 => is not almost 2.1 precision 0.01)]
-    #[test_case(1.0 => is not not not not lt 3.0)] // Yeah, that's legal
     fn not_complex(input: f32) -> f32 { input * 1.0 }
 
     #[test_case("Cargo.yaml".parse().unwrap() => is not existing_path)]
@@ -279,5 +278,12 @@ mod test_cases {
     #[test_case(2.0 => it (eq 2.0))]
     fn in_parens(_: f32) -> f32 {
         2.0
+    }
+
+    #[test_case(1.0 => is gt 0.0 and lt 5.0)]
+    #[test_case(1.0 => is gt 0.0 or lt 0.0)]
+    #[test_case(-2.0 => is gt 0.0 or lt 0.0)]
+    fn combinators(v: f32) -> f32 {
+        v * 2.0
     }
 }

--- a/src/complex_expr.rs
+++ b/src/complex_expr.rs
@@ -295,7 +295,7 @@ fn parse_kw_repeat<Keyword: Parse>(
     input: ParseStream,
 ) -> syn::Result<Vec<ComplexTestCase>> {
     let mut acc = vec![first];
-    while let Ok(_) = input.parse::<Keyword>() {
+    while input.parse::<Keyword>().is_ok() {
         acc.push(ComplexTestCase::parse_single_item(input)?);
     }
     Ok(acc)

--- a/src/complex_expr.rs
+++ b/src/complex_expr.rs
@@ -153,12 +153,12 @@ impl Display for ComplexTestCase {
                 fmt_syn(expected_value),
                 fmt_syn(precision)
             ),
-            ComplexTestCase::Path(Path { token }) => write!(f, "{}", token),
+            ComplexTestCase::Path(Path { token }) => write!(f, "path {}", token),
             ComplexTestCase::Contains(Contains { expected_element }) => {
-                write!(f, "{}", fmt_syn(expected_element))
+                write!(f, "contains {}", fmt_syn(expected_element))
             }
             ComplexTestCase::ContainsInOrder(ContainsInOrder { expected_slice }) => {
-                write!(f, "{}", fmt_syn(expected_slice))
+                write!(f, "contains in order {}", fmt_syn(expected_slice))
             }
         }
     }
@@ -266,11 +266,11 @@ impl ComplexTestCase {
 
 fn and_assertion(cases: &[ComplexTestCase]) -> TokenStream {
     let ts = cases[0].boolean_check();
-    let mut ts: TokenStream = parse_quote! { {#ts} };
+    let mut ts: TokenStream = parse_quote! { #ts };
 
     for case in cases.iter().skip(1) {
         let case = case.boolean_check();
-        let case: TokenStream = parse_quote! { && {#case} };
+        let case: TokenStream = parse_quote! { && #case };
         ts.append_all(case);
     }
 
@@ -279,11 +279,11 @@ fn and_assertion(cases: &[ComplexTestCase]) -> TokenStream {
 
 fn or_assertion(cases: &[ComplexTestCase]) -> TokenStream {
     let ts = cases[0].boolean_check();
-    let mut ts: TokenStream = parse_quote! { {#ts} };
+    let mut ts: TokenStream = parse_quote! { #ts };
 
     for case in cases.iter().skip(1) {
         let case = case.boolean_check();
-        let case: TokenStream = parse_quote! { || {#case} };
+        let case: TokenStream = parse_quote! { || #case };
         ts.append_all(case);
     }
 

--- a/src/complex_expr.rs
+++ b/src/complex_expr.rs
@@ -463,4 +463,10 @@ mod tests {
             })
         )
     }
+
+    #[test]
+    fn parses_negation() {
+        let actual: ComplexTestCase = parse_quote! { not eq 1.0 };
+        assert!(matches!(actual, ComplexTestCase::Not(_)))
+    }
 }

--- a/src/complex_expr.rs
+++ b/src/complex_expr.rs
@@ -275,7 +275,7 @@ fn ord_assertion(token: &OrderingToken, expected_value: &Expr) -> TokenStream {
 
 fn not_assertion(not: &ComplexTestCase) -> TokenStream {
     match not {
-        ComplexTestCase::Not(not) => not_assertion(not),
+        ComplexTestCase::Not(not) => negate(not_assertion(not)),
         ComplexTestCase::Ord(Ord {
             token,
             expected_value,

--- a/src/complex_expr.rs
+++ b/src/complex_expr.rs
@@ -467,6 +467,9 @@ mod tests {
     #[test]
     fn parses_negation() {
         let actual: ComplexTestCase = parse_quote! { not eq 1.0 };
-        assert!(matches!(actual, ComplexTestCase::Not(_)))
+        match actual {
+            ComplexTestCase::Not(_) => {}
+            _ => panic!("test failed"),
+        };
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -79,13 +79,11 @@ impl Display for TestCaseResult {
         match self {
             TestCaseResult::Simple(expr) => write!(f, "{}", fmt_syn(expr)),
             TestCaseResult::Matching(expr) => write!(f, "matching {}", fmt_syn(expr)),
-            TestCaseResult::Panicking(expr) => {
-                write!(
-                    f,
-                    "panicking {:?}",
-                    expr.as_ref().map(|inner| fmt_syn(&inner))
-                )
-            }
+            TestCaseResult::Panicking(expr) => write!(
+                f,
+                "panicking {:?}",
+                expr.as_ref().map(|inner| fmt_syn(&inner))
+            ),
             TestCaseResult::With(expr) => write!(f, "with {}", fmt_syn(expr)),
             TestCaseResult::UseFn(path) => write!(f, "use {}", fmt_syn(path)),
             TestCaseResult::Complex(complex) => write!(f, "complex {}", complex),

--- a/tests/snapshots/rust-1.41.0/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-1.41.0/acceptance__acceptance__basic.snap
@@ -4,9 +4,9 @@ expression: lines
 
 ---
 running 0 tests
-running 70 tests
+running 78 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 67 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+test result: ok. 75 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok
 test test_cases::abs_tests::returns_opposite_number_for_non_positive_input ... ok
@@ -56,6 +56,14 @@ test test_cases::name::test_3_6_9 ... ok
 test test_cases::nested::nested_test_case::_1_1_expects ... ok
 test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_not_eq_2_0 ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
+test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok
+test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path ... ok
+test test_cases::not_path::_src_parse_unwrap_expects_complex_not_file ... ok
 test test_cases::panicing::_expects_panicking_some_it_has_to_panic_ ... ok
 test test_cases::panics_without_value::_expects_panicking_none ... ok
 test test_cases::pattern_matching_result::simpleenum_var2_expects_matching_simpleenum_var2 ... ok

--- a/tests/snapshots/rust-1.41.0/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-1.41.0/acceptance__acceptance__basic.snap
@@ -4,15 +4,28 @@ expression: lines
 
 ---
 running 0 tests
-running 78 tests
+running 91 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 75 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+test result: ok. 88 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok
 test test_cases::abs_tests::returns_opposite_number_for_non_positive_input ... ok
 test test_cases::arg_expressions::_2_4_6_to_string_expects ... ok
 test test_cases::bar::_expects_string_default_ ... ok
 test test_cases::basic_test::_1_expects ... ok
+test test_cases::combinators::_0_3_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
+test test_cases::combinators::_0_7_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_and_lt_5_0 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_or_lt_0_0 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_or_lt_1_5_and_lt_2_0 ... ok
+test test_cases::combinators::_2_0_expects_complex_gt_0_0_or_lt_0_0 ... ok
+test test_cases::combinators::_2_0_expects_complex_gt_0_0_or_lt_0_0_and_lt_1_0 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_and_contains_2_and_contains_in_order_2_3_ ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_and_contains_3_or_contains_5 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_or_contains_4 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_or_contains_4_and_contains_2 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_6_and_contains_7_or_contains_1 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_6_and_contains_7_or_contains_1_and_contains_in_order_1_2_3_ ... ok
 test test_cases::complex_tests::almost_eq1 ... ok
 test test_cases::complex_tests::almost_eq2 ... ok
 test test_cases::complex_tests::eq1 ... ok
@@ -26,10 +39,10 @@ test test_cases::complex_tests::leq2 ... ok
 test test_cases::complex_tests::lt1 ... ok
 test test_cases::complex_tests::lt2 ... ok
 test test_cases::const_in_arg::this_is_desc_not_an_argument ... ok
-test test_cases::contains_tests::vec_1_2_3_4_expects_complex_1 ... ok
-test test_cases::contains_tests::vec_1_2_3_4_expects_complex_3_4_ ... ok
-test test_cases::create_path::_cargo_toml_expects_complex_path ... ok
-test test_cases::create_path::_src_lib_rs_expects_complex_file ... ok
+test test_cases::contains_tests::vec_1_2_3_4_expects_complex_contains_1 ... ok
+test test_cases::contains_tests::vec_1_2_3_4_expects_complex_contains_in_order_3_4_ ... ok
+test test_cases::create_path::_cargo_toml_expects_complex_path_path ... ok
+test test_cases::create_path::_src_lib_rs_expects_complex_path_file ... ok
 test test_cases::create_path::long_dir ... ok
 test test_cases::create_path::short_dir ... ok
 test test_cases::divide_by_zero_f64_with_lambda::_0_0_expects_with_v_f64_assert_v_is_nan_ ... ok
@@ -38,6 +51,7 @@ test test_cases::fancy_addition::some_2_3_some_4_expects_2_3_4 ... ok
 test test_cases::fancy_addition::some_2_some_3_expects_5 ... ok
 test test_cases::fancy_addition::treats_none_as_0 ... ok
 test test_cases::impl_trait::_foo_expects ... ok
+test test_cases::in_parens::_2_0_expects_complex_eq_2_0 ... ok
 test test_cases::inconclusives::_expects_inconclusive_ ... ignored
 test test_cases::inconclusives::inconclusive_test ... ignored
 test test_cases::inconclusives::test_is_not_ran ... ignored
@@ -58,12 +72,11 @@ test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
-test test_cases::not_complex::_1_0_expects_complex_not_not_not_not_lt_3_0 ... ok
-test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
-test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
-test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok
-test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path ... ok
-test test_cases::not_path::_src_parse_unwrap_expects_complex_not_file ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_5 ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_in_order_3_2_ ... ok
+test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_path_dir ... ok
+test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path_path ... ok
+test test_cases::not_path::_src_parse_unwrap_expects_complex_not_path_file ... ok
 test test_cases::panicing::_expects_panicking_some_it_has_to_panic_ ... ok
 test test_cases::panics_without_value::_expects_panicking_none ... ok
 test test_cases::pattern_matching_result::simpleenum_var2_expects_matching_simpleenum_var2 ... ok

--- a/tests/snapshots/rust-1.41.0/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-1.41.0/acceptance__acceptance__basic.snap
@@ -58,7 +58,7 @@ test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
-test test_cases::not_complex::_1_0_expects_complex_not_not_eq_2_0 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_not_not_not_lt_3_0 ... ok
 test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
 test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
 test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok

--- a/tests/snapshots/rust-nightly/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-nightly/acceptance__acceptance__basic.snap
@@ -4,9 +4,9 @@ expression: lines
 
 ---
 running 0 tests
-running 70 tests
+running 78 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 67 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+test result: ok. 75 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok
 test test_cases::abs_tests::returns_opposite_number_for_non_positive_input ... ok
@@ -56,6 +56,14 @@ test test_cases::name::test_3_6_9 ... ok
 test test_cases::nested::nested_test_case::_1_1_expects ... ok
 test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_not_eq_2_0 ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
+test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok
+test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path ... ok
+test test_cases::not_path::_src_parse_unwrap_expects_complex_not_file ... ok
 test test_cases::panicing::_expects_panicking_some_it_has_to_panic_ - should panic ... ok
 test test_cases::panics_without_value::_expects_panicking_none - should panic ... ok
 test test_cases::pattern_matching_result::simpleenum_var2_expects_matching_simpleenum_var2 ... ok

--- a/tests/snapshots/rust-nightly/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-nightly/acceptance__acceptance__basic.snap
@@ -58,7 +58,7 @@ test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
-test test_cases::not_complex::_1_0_expects_complex_not_not_eq_2_0 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_not_not_not_lt_3_0 ... ok
 test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
 test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
 test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok

--- a/tests/snapshots/rust-nightly/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-nightly/acceptance__acceptance__basic.snap
@@ -4,15 +4,28 @@ expression: lines
 
 ---
 running 0 tests
-running 78 tests
+running 91 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 75 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+test result: ok. 88 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok
 test test_cases::abs_tests::returns_opposite_number_for_non_positive_input ... ok
 test test_cases::arg_expressions::_2_4_6_to_string_expects ... ok
 test test_cases::bar::_expects_string_default_ ... ok
 test test_cases::basic_test::_1_expects ... ok
+test test_cases::combinators::_0_3_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
+test test_cases::combinators::_0_7_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_and_lt_5_0 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_or_lt_0_0 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_or_lt_1_5_and_lt_2_0 ... ok
+test test_cases::combinators::_2_0_expects_complex_gt_0_0_or_lt_0_0 ... ok
+test test_cases::combinators::_2_0_expects_complex_gt_0_0_or_lt_0_0_and_lt_1_0 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_and_contains_2_and_contains_in_order_2_3_ ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_and_contains_3_or_contains_5 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_or_contains_4 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_or_contains_4_and_contains_2 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_6_and_contains_7_or_contains_1 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_6_and_contains_7_or_contains_1_and_contains_in_order_1_2_3_ ... ok
 test test_cases::complex_tests::almost_eq1 ... ok
 test test_cases::complex_tests::almost_eq2 ... ok
 test test_cases::complex_tests::eq1 ... ok
@@ -26,10 +39,10 @@ test test_cases::complex_tests::leq2 ... ok
 test test_cases::complex_tests::lt1 ... ok
 test test_cases::complex_tests::lt2 ... ok
 test test_cases::const_in_arg::this_is_desc_not_an_argument ... ok
-test test_cases::contains_tests::vec_1_2_3_4_expects_complex_1 ... ok
-test test_cases::contains_tests::vec_1_2_3_4_expects_complex_3_4_ ... ok
-test test_cases::create_path::_cargo_toml_expects_complex_path ... ok
-test test_cases::create_path::_src_lib_rs_expects_complex_file ... ok
+test test_cases::contains_tests::vec_1_2_3_4_expects_complex_contains_1 ... ok
+test test_cases::contains_tests::vec_1_2_3_4_expects_complex_contains_in_order_3_4_ ... ok
+test test_cases::create_path::_cargo_toml_expects_complex_path_path ... ok
+test test_cases::create_path::_src_lib_rs_expects_complex_path_file ... ok
 test test_cases::create_path::long_dir ... ok
 test test_cases::create_path::short_dir ... ok
 test test_cases::divide_by_zero_f64_with_lambda::_0_0_expects_with_v_f64_assert_v_is_nan_ ... ok
@@ -38,6 +51,7 @@ test test_cases::fancy_addition::some_2_3_some_4_expects_2_3_4 ... ok
 test test_cases::fancy_addition::some_2_some_3_expects_5 ... ok
 test test_cases::fancy_addition::treats_none_as_0 ... ok
 test test_cases::impl_trait::_foo_expects ... ok
+test test_cases::in_parens::_2_0_expects_complex_eq_2_0 ... ok
 test test_cases::inconclusives::_expects_inconclusive_ ... ignored
 test test_cases::inconclusives::inconclusive_test ... ignored
 test test_cases::inconclusives::test_is_not_ran ... ignored
@@ -58,12 +72,11 @@ test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
-test test_cases::not_complex::_1_0_expects_complex_not_not_not_not_lt_3_0 ... ok
-test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
-test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
-test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok
-test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path ... ok
-test test_cases::not_path::_src_parse_unwrap_expects_complex_not_file ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_5 ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_in_order_3_2_ ... ok
+test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_path_dir ... ok
+test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path_path ... ok
+test test_cases::not_path::_src_parse_unwrap_expects_complex_not_path_file ... ok
 test test_cases::panicing::_expects_panicking_some_it_has_to_panic_ - should panic ... ok
 test test_cases::panics_without_value::_expects_panicking_none - should panic ... ok
 test test_cases::pattern_matching_result::simpleenum_var2_expects_matching_simpleenum_var2 ... ok

--- a/tests/snapshots/rust-stable/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-stable/acceptance__acceptance__basic.snap
@@ -4,9 +4,9 @@ expression: lines
 
 ---
 running 0 tests
-running 70 tests
+running 78 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 67 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+test result: ok. 75 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok
 test test_cases::abs_tests::returns_opposite_number_for_non_positive_input ... ok
@@ -56,6 +56,14 @@ test test_cases::name::test_3_6_9 ... ok
 test test_cases::nested::nested_test_case::_1_1_expects ... ok
 test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_not_eq_2_0 ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
+test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok
+test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path ... ok
+test test_cases::not_path::_src_parse_unwrap_expects_complex_not_file ... ok
 test test_cases::panicing::_expects_panicking_some_it_has_to_panic_ - should panic ... ok
 test test_cases::panics_without_value::_expects_panicking_none - should panic ... ok
 test test_cases::pattern_matching_result::simpleenum_var2_expects_matching_simpleenum_var2 ... ok

--- a/tests/snapshots/rust-stable/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-stable/acceptance__acceptance__basic.snap
@@ -58,7 +58,7 @@ test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
-test test_cases::not_complex::_1_0_expects_complex_not_not_eq_2_0 ... ok
+test test_cases::not_complex::_1_0_expects_complex_not_not_not_not_lt_3_0 ... ok
 test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
 test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
 test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok

--- a/tests/snapshots/rust-stable/acceptance__acceptance__basic.snap
+++ b/tests/snapshots/rust-stable/acceptance__acceptance__basic.snap
@@ -4,15 +4,28 @@ expression: lines
 
 ---
 running 0 tests
-running 78 tests
+running 91 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 75 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+test result: ok. 88 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
 test test_cases::abs_tests::returns_0_for_0 ... ok
 test test_cases::abs_tests::returns_given_number_for_positive_input ... ok
 test test_cases::abs_tests::returns_opposite_number_for_non_positive_input ... ok
 test test_cases::arg_expressions::_2_4_6_to_string_expects ... ok
 test test_cases::bar::_expects_string_default_ ... ok
 test test_cases::basic_test::_1_expects ... ok
+test test_cases::combinators::_0_3_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
+test test_cases::combinators::_0_7_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_and_lt_5_0 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_or_lt_0_0 ... ok
+test test_cases::combinators::_1_0_expects_complex_gt_0_0_or_lt_1_5_and_lt_2_0 ... ok
+test test_cases::combinators::_2_0_expects_complex_gt_0_0_or_lt_0_0 ... ok
+test test_cases::combinators::_2_0_expects_complex_gt_0_0_or_lt_0_0_and_lt_1_0 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_and_contains_2_and_contains_in_order_2_3_ ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_and_contains_3_or_contains_5 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_or_contains_4 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_1_or_contains_4_and_contains_2 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_6_and_contains_7_or_contains_1 ... ok
+test test_cases::combinators_with_arrays::vec_1_2_3_expects_complex_contains_6_and_contains_7_or_contains_1_and_contains_in_order_1_2_3_ ... ok
 test test_cases::complex_tests::almost_eq1 ... ok
 test test_cases::complex_tests::almost_eq2 ... ok
 test test_cases::complex_tests::eq1 ... ok
@@ -26,10 +39,10 @@ test test_cases::complex_tests::leq2 ... ok
 test test_cases::complex_tests::lt1 ... ok
 test test_cases::complex_tests::lt2 ... ok
 test test_cases::const_in_arg::this_is_desc_not_an_argument ... ok
-test test_cases::contains_tests::vec_1_2_3_4_expects_complex_1 ... ok
-test test_cases::contains_tests::vec_1_2_3_4_expects_complex_3_4_ ... ok
-test test_cases::create_path::_cargo_toml_expects_complex_path ... ok
-test test_cases::create_path::_src_lib_rs_expects_complex_file ... ok
+test test_cases::contains_tests::vec_1_2_3_4_expects_complex_contains_1 ... ok
+test test_cases::contains_tests::vec_1_2_3_4_expects_complex_contains_in_order_3_4_ ... ok
+test test_cases::create_path::_cargo_toml_expects_complex_path_path ... ok
+test test_cases::create_path::_src_lib_rs_expects_complex_path_file ... ok
 test test_cases::create_path::long_dir ... ok
 test test_cases::create_path::short_dir ... ok
 test test_cases::divide_by_zero_f64_with_lambda::_0_0_expects_with_v_f64_assert_v_is_nan_ ... ok
@@ -38,6 +51,7 @@ test test_cases::fancy_addition::some_2_3_some_4_expects_2_3_4 ... ok
 test test_cases::fancy_addition::some_2_some_3_expects_5 ... ok
 test test_cases::fancy_addition::treats_none_as_0 ... ok
 test test_cases::impl_trait::_foo_expects ... ok
+test test_cases::in_parens::_2_0_expects_complex_eq_2_0 ... ok
 test test_cases::inconclusives::_expects_inconclusive_ ... ignored
 test test_cases::inconclusives::inconclusive_test ... ignored
 test test_cases::inconclusives::test_is_not_ran ... ignored
@@ -58,12 +72,11 @@ test test_cases::nested::using_fn_from_super::_20_22_expects ... ok
 test test_cases::nested::using_fn_from_super::_42_expects ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test test_cases::not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
-test test_cases::not_complex::_1_0_expects_complex_not_not_not_not_lt_3_0 ... ok
-test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_3_2_ ... ok
-test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_5 ... ok
-test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_dir ... ok
-test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path ... ok
-test test_cases::not_path::_src_parse_unwrap_expects_complex_not_file ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_5 ... ok
+test test_cases::not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_in_order_3_2_ ... ok
+test test_cases::not_path::_cargo_toml_parse_unwrap_expects_complex_not_path_dir ... ok
+test test_cases::not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path_path ... ok
+test test_cases::not_path::_src_parse_unwrap_expects_complex_not_path_file ... ok
 test test_cases::panicing::_expects_panicking_some_it_has_to_panic_ - should panic ... ok
 test test_cases::panics_without_value::_expects_panicking_none - should panic ... ok
 test test_cases::pattern_matching_result::simpleenum_var2_expects_matching_simpleenum_var2 ... ok


### PR DESCRIPTION
`it` and `is` now support negation and logic.
One caveat is `()` are needed to mix `and` and `or`. `A and B or C` is forbidden - I wanted to avoid adding some more complex parsing.

This is planned to release as 2.0.0-rc2