### PR TITLE
Add a compilation error if a test-case has a Result type but no check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ path = "tests/acceptance_tests.rs"
 [features]
 default = []
 hamcrest_assertions = []
-allow_return = []
+allow_result = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ path = "tests/acceptance_tests.rs"
 [features]
 default = []
 hamcrest_assertions = []
+allow_return = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,10 @@ cfg-if = "1.0.0"
 version_check = "0.9.2"
 
 [dev-dependencies]
-insta = "1.7.0"
+insta = "<1.12.0"
 lazy_static = "1.4.0"
 itertools = "0.10.0"
+indexmap = "<1.8.0"
 
 [[test]]
 name = "acceptance"

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The simplest way to remedy this is to append `... => Ok(_)' to each `#[test-case
 #[test_case( 0 => Ok(_) ; "Test with 0")]
 ```
 
-As of version 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compiltion error.
+Previously tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_return` will disable the check.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The simplest way to remedy this is to append `... => Ok(_)` to each `#[test-case
 #[test_case( 0 => Ok(_) ; "Test with 0")]
 ```
 
-Previously, tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_return` will disable the check.
+Previously, tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_result` will disable the check.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -253,16 +253,16 @@ async fn runs_async_task(input: &str) -> bool {
 }
 ```
 
-## Porting from Rust `#[test]`s with return types
+## Porting from Rust `#[test]`s with `Result` types
 
 It is important to note that test-case does not support the [Rust 2018+ idiom](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html#tests-and-) of failing tests by returning a `Result<T, E>` with an error type.
-The simplest way to remedy this is to append `... => Ok(_)' to each `#[test-case(...)` expression, e.g:
+The simplest way to remedy this is to append `... => Ok(_)` to each `#[test-case(...)` expression, e.g:
 
 ```rust
 #[test_case( 0 => Ok(_) ; "Test with 0")]
 ```
 
-Previously tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_return` will disable the check.
+Previously, tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_return` will disable the check.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -253,6 +253,17 @@ async fn runs_async_task(input: &str) -> bool {
 }
 ```
 
+## Porting from Rust `#[test]`s with return types
+
+It is important to note that test-case does not support the [Rust 2018+ idiom](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html#tests-and-) of failing tests by returning a `Result<T, E>` with an error type.
+The simplest way to remedy this is to append `... => Ok(_)' to each `#[test-case(...)` expression, e.g:
+
+```rust
+#[test_case( 0 => Ok(_) ; "Test with 0")]
+```
+
+As of version 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compiltion error.
+
 
 ## License
 

--- a/acceptance_tests/return_check/.gitignore
+++ b/acceptance_tests/return_check/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/acceptance_tests/return_check/Cargo.toml
+++ b/acceptance_tests/return_check/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-case-test"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/acceptance_tests/return_check/Cargo.toml
+++ b/acceptance_tests/return_check/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test-case-test"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+test-case = { path = "../.." }

--- a/acceptance_tests/return_check/Cargo.toml
+++ b/acceptance_tests/return_check/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 test-case = { path = "../.." }
+
+[features]
+allow_return = ["test-case/allow_return"]

--- a/acceptance_tests/return_check/Cargo.toml
+++ b/acceptance_tests/return_check/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 test-case = { path = "../.." }
 
 [features]
-allow_return = ["test-case/allow_return"]
+allow_result = ["test-case/allow_result"]

--- a/acceptance_tests/return_check/src/lib.rs
+++ b/acceptance_tests/return_check/src/lib.rs
@@ -1,0 +1,27 @@
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    #[test_case(2, 2; "Wrong")]
+    #[test_case(2, 3; "Right")]
+    fn return_no_expect(a: i32, b: i32) -> Result<i32, String> {
+        let result = a + b;
+        return if result == 5 {
+            Ok(result)
+        } else {
+            Err("Not equal 5".to_owned())
+        }
+    }
+
+    #[test_case(2, 2 => Err("Not equal 5".to_owned()); "Wrong")]
+    #[test_case(2, 3 => Ok(5); "Right")]
+    fn return_with_expect(a: i32, b: i32) -> Result<i32, String> {
+        let result = a + b;
+        return if result == 5 {
+            Ok(result)
+        } else {
+            Err("Not equal 5".to_owned())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,16 +253,16 @@
 //! }
 //! ```
 //!
-//! # Porting from Rust `#[test]`s with return types
+//! # Porting from Rust `#[test]`s with `Result` types
 //!
 //! It is important to note that test-case does not support the [Rust 2018+ idiom](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html#tests-and-) of failing tests by returning a `Result<T, E>` with an error type.
-//! The simplest way to remedy this is to append `... => Ok(_)' to each `#[test-case(...)` expression, e.g:
+//! The simplest way to remedy this is to append `... => Ok(_)` to each `#[test-case(...)` expression, e.g:
 //!
 //! ```rust
 //! #[test_case( 0 => Ok(_) ; "Test with 0")]
 //! ```
 //!
-//! Previously tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_return` will disable the check.
+//! Previously, tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_return` will disable the check.
 //!
 
 extern crate proc_macro;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 
-use syn::{parse_macro_input, ItemFn, ReturnType};
+use syn::{parse_macro_input, ItemFn};
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -348,6 +348,8 @@ pub fn test_case(args: TokenStream, input: TokenStream) -> TokenStream {
                     .into()
                 }
             };
+
+            #[cfg(not(feature = "allow_return"))]
             if let Err(err) = check_return(&test_case, &item) {
                 return err;
             }
@@ -364,7 +366,10 @@ pub fn test_case(args: TokenStream, input: TokenStream) -> TokenStream {
     render_test_cases(&test_cases, item)
 }
 
+#[cfg(not(feature = "allow_return"))]
 fn check_return(test_case: &TestCase, item: &ItemFn) -> Result<(), TokenStream> {
+    use syn::ReturnType;
+
     let fn_ret = &item.sig.output;
     match fn_ret {
         ReturnType::Type(_, ret_type) if  !test_case.expects_return() =>  {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,17 @@
 //! }
 //! ```
 //!
+//! # Porting from Rust `#[test]`s with return types
+//!
+//! It is important to note that test-case does not support the [Rust 2018+ idiom](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html#tests-and-) of failing tests by returning a `Result<T, E>` with an error type.
+//! The simplest way to remedy this is to append `... => Ok(_)' to each `#[test-case(...)` expression, e.g:
+//!
+//! ```rust
+//! #[test_case( 0 => Ok(_) ; "Test with 0")]
+//! ```
+//!
+//! As of version 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compiltion error.
+//!
 
 extern crate proc_macro;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@
 //! #[test_case( 0 => Ok(_) ; "Test with 0")]
 //! ```
 //!
-//! As of version 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compiltion error.
+//! Previously tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_return` will disable the check.
 //!
 
 extern crate proc_macro;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@
 //! #[test_case( 0 => Ok(_) ; "Test with 0")]
 //! ```
 //!
-//! Previously, tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_return` will disable the check.
+//! Previously, tests relying on the return error being checked would silently pass; as of 1.2.2 attempting to return a `Result<>` without an appropriate return check in the expression will result in a compilation error. However if you wish to keep the old behaviour for some reason the feature flag `allow_result` will disable the check.
 //!
 
 extern crate proc_macro;
@@ -360,8 +360,8 @@ pub fn test_case(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
             };
 
-            #[cfg(not(feature = "allow_return"))]
-            if let Err(err) = check_return(&test_case, &item) {
+            #[cfg(not(feature = "allow_result"))]
+            if let Err(err) = check_for_result(&test_case, &item) {
                 return err;
             }
 
@@ -377,8 +377,8 @@ pub fn test_case(args: TokenStream, input: TokenStream) -> TokenStream {
     render_test_cases(&test_cases, item)
 }
 
-#[cfg(not(feature = "allow_return"))]
-fn check_return(test_case: &TestCase, item: &ItemFn) -> Result<(), TokenStream> {
+#[cfg(not(feature = "allow_result"))]
+fn check_for_result(test_case: &TestCase, item: &ItemFn) -> Result<(), TokenStream> {
     use syn::ReturnType;
 
     let fn_ret = &item.sig.output;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,9 +360,12 @@ pub fn test_case(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
             };
 
-            #[cfg(not(feature = "allow_result"))]
-            if let Err(err) = check_for_result(&test_case, &item) {
-                return err;
+            cfg_if::cfg_if! {
+                if #[cfg(not(feature = "allow_result"))] {
+                    if let Err(err) = check_for_result(&test_case, &item) {
+                        return err;
+                    }
+                }
             }
 
             test_cases.push(test_case);

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -33,7 +33,7 @@ impl Parse for TestCase {
         let expected = if arrow.is_some() {
             let expected: Expected = input.parse()?;
 
-            test_case_name += &format!(" {}", expected.to_string());
+            test_case_name += &format!(" {}", expected);
 
             Some(expected)
         } else {

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -67,6 +67,7 @@ impl TestCase {
         crate::utils::escape_test_name(case_desc)
     }
 
+    #[cfg(not(feature = "allow_return"))]
     pub fn expects_return(&self) -> bool {
         match self.expected {
             Some(Expected::Pattern(_)) => true,

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -67,6 +67,18 @@ impl TestCase {
         crate::utils::escape_test_name(case_desc)
     }
 
+    pub fn expects_return(&self) -> bool {
+        match self.expected {
+            Some(Expected::Pattern(_)) => true,
+            Some(Expected::Panic(_)) => false,
+            Some(Expected::Expr(_)) => true,
+            Some(Expected::Ignore(_)) => false,
+            #[cfg(any(feature = "hamcrest_assertions", test))]
+            Some(Expected::Hamcrest(_)) => true,
+            None => false,
+        }
+    }
+
     pub fn render(&self, mut item: ItemFn) -> TokenStream2 {
         let item_name = item.sig.ident.clone();
         let arg_values = self.args.iter();

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -67,7 +67,7 @@ impl TestCase {
         crate::utils::escape_test_name(case_desc)
     }
 
-    #[cfg(not(feature = "allow_return"))]
+    #[cfg(not(feature = "allow_result"))]
     pub fn expects_return(&self) -> bool {
         match self.expected {
             Some(Expected::Pattern(_)) => true,

--- a/tests/acceptance_tests.rs
+++ b/tests/acceptance_tests.rs
@@ -109,5 +109,4 @@ mod acceptance {
             assert!(output.status.success());
         });
     }
-
 }

--- a/tests/acceptance_tests.rs
+++ b/tests/acceptance_tests.rs
@@ -98,11 +98,11 @@ mod acceptance {
     }
 
     #[test]
-    fn allow_return_check() {
+    fn allow_result_check() {
         with_settings!({snapshot_path => get_snapshot_directory()}, {
             let output = Command::new("cargo")
                 .current_dir(PathBuf::from("acceptance_tests").join("return_check"))
-                .args(&["test", "--features", "allow_return"])
+                .args(&["test", "--features", "allow_result"])
                 .output()
                 .expect("cargo command failed to start");
 

--- a/tests/acceptance_tests.rs
+++ b/tests/acceptance_tests.rs
@@ -15,8 +15,8 @@ mod acceptance {
             .to_string()
     }
 
-    fn retrieve_stdout(output: &Output) -> String {
-        String::from_utf8_lossy(&output.stdout)
+    fn retrieve_output(output: &Vec<u8>) -> String {
+        String::from_utf8_lossy(&output)
             .to_string()
             .lines()
             .filter(|s| !s.is_empty())
@@ -26,6 +26,14 @@ mod acceptance {
             })
             .sorted()
             .join("\n")
+    }
+
+    fn retrieve_stdout(output: &Output) -> String {
+        retrieve_output(&output.stdout)
+    }
+
+    fn retrieve_stderr(output: &Output) -> String {
+        retrieve_output(&output.stderr)
     }
 
     #[test]
@@ -69,4 +77,23 @@ mod acceptance {
             insta::assert_display_snapshot!(lines);
         });
     }
+
+    #[test]
+    fn return_check() {
+        with_settings!({snapshot_path => get_snapshot_directory()}, {
+            let output = Command::new("cargo")
+                .current_dir(PathBuf::from("acceptance_tests").join("return_check"))
+                .args(&["test"])
+                .output()
+                .expect("cargo command failed to start");
+
+            let stderr = retrieve_stderr(&output);
+
+            // We need to check stderr for the expected compile
+            // failure, but that includes other volatile output, so
+            // resort to manual inspection for now.
+            assert!(stderr.contains("Test function return_no_expect has a return-type but no exected clause in the test-case."));
+        });
+    }
+
 }

--- a/tests/acceptance_tests.rs
+++ b/tests/acceptance_tests.rs
@@ -87,12 +87,26 @@ mod acceptance {
                 .output()
                 .expect("cargo command failed to start");
 
-            let stderr = retrieve_stderr(&output);
+            assert!(!output.status.success());
 
             // We need to check stderr for the expected compile
             // failure, but that includes other volatile output, so
             // resort to manual inspection for now.
+            let stderr = retrieve_stderr(&output);
             assert!(stderr.contains("Test function return_no_expect has a return-type but no exected clause in the test-case."));
+        });
+    }
+
+    #[test]
+    fn allow_return_check() {
+        with_settings!({snapshot_path => get_snapshot_directory()}, {
+            let output = Command::new("cargo")
+                .current_dir(PathBuf::from("acceptance_tests").join("return_check"))
+                .args(&["test", "--features", "allow_return"])
+                .output()
+                .expect("cargo command failed to start");
+
+            assert!(output.status.success());
         });
     }
 

--- a/tests/acceptance_tests.rs
+++ b/tests/acceptance_tests.rs
@@ -9,14 +9,14 @@ mod acceptance {
 
     fn get_snapshot_directory() -> String {
         PathBuf::from("snapshots")
-            .join(env::var("SNAPSHOT_DIR").unwrap_or("rust-stable".to_string()))
+            .join(env::var("SNAPSHOT_DIR").unwrap_or_else(|_| "rust-stable".to_string()))
             .to_str()
             .unwrap()
             .to_string()
     }
 
-    fn retrieve_output(output: &Vec<u8>) -> String {
-        String::from_utf8_lossy(&output)
+    fn retrieve_output(output: &[u8]) -> String {
+        String::from_utf8_lossy(output)
             .to_string()
             .lines()
             .filter(|s| !s.is_empty())


### PR DESCRIPTION
This adds a compile-time check for test-cases that return `Result` but don't have a corresponding test in their expression. See  #50.

As this might break things for some people I've also added a feature flag `allow_result` which will disable the check, off by default.

Currently the async acceptance test is failing, but this appears to be unrelated to these changes. It looks like it just needs a review of the `insta` snapshot.