### PR TITLE
Add 'len', 'count' and 'empty' complex assertions

### DIFF
--- a/tests/acceptance_cases/cases_support_complex_assertions/src/lib.rs
+++ b/tests/acceptance_cases/cases_support_complex_assertions/src/lib.rs
@@ -74,3 +74,46 @@ fn combinators(v: f32) -> f32 {
 fn combinators_with_arrays(a: Vec<u8>) -> Vec<u8> {
     a
 }
+
+#[test_case(vec![0, 1, 3] => is len 3)]
+#[test_case(vec![0, 1] => it has_length 2)]
+fn len_vec(v: Vec<u8>) -> Vec<u8> {
+    v
+}
+
+#[test_case("abc" => is len 3)]
+#[test_case("ab" => it has_length 2)]
+fn len_str(v: &str) -> &str {
+    v
+}
+
+#[test_case("abc" => is len 3)]
+#[test_case("ab" => it has_length 2)]
+fn len_string(v: &str) -> String {
+    v.to_string()
+}
+
+#[test_case(b"abc" => is len 3)]
+#[test_case(b"ab" => it has_length 2)]
+fn len_byte_str(v: &[u8]) -> &[u8] {
+    v
+}
+
+#[test_case(vec![0, 1, 3] => is count 3)]
+#[test_case(vec![0, 1] => it has_count 2)]
+fn count_vec(v: Vec<u8>) -> Vec<u8> {
+    v
+}
+
+#[test_case(vec![0, 1, 3] => is count 3)]
+#[test_case("abcd".chars() => is count 4)]
+#[test_case(std::iter::once(2) => is count 1)]
+fn count_general<T>(v: impl IntoIterator<Item = T>) -> impl IntoIterator<Item = T> {
+    v
+}
+
+#[test_case(vec![0] => is empty)]
+#[test_case(vec![] => is empty)]
+fn empty(v: Vec<u8>) -> Vec<u8> {
+    v
+}

--- a/tests/snapshots/rust-1.49.0/acceptance__cases_support_complex_assertions.snap
+++ b/tests/snapshots/rust-1.49.0/acceptance__cases_support_complex_assertions.snap
@@ -1,9 +1,13 @@
 ---
 source: tests/acceptance_tests.rs
-assertion_line: 100
+assertion_line: 107
 expression: output
 ---
-running 39 tests
+    empty::vec_0_expects_complex_empty
+---- empty::vec_0_expects_complex_empty stdout ----
+failures:
+failures:
+running 54 tests
 test combinators::_0_3_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
 test combinators::_0_7_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
 test combinators::_1_0_expects_complex_gt_0_0_and_lt_5_0 ... ok
@@ -31,11 +35,26 @@ test complex_tests::lt1 ... ok
 test complex_tests::lt2 ... ok
 test contains_tests::vec_1_2_3_4_expects_complex_contains_1 ... ok
 test contains_tests::vec_1_2_3_4_expects_complex_contains_in_order_3_4_ ... ok
+test count_general::_abcd_chars_expects_complex_count_4 ... ok
+test count_general::std_iter_once_2_expects_complex_count_1 ... ok
+test count_general::vec_0_1_3_expects_complex_count_3 ... ok
+test count_vec::vec_0_1_3_expects_complex_count_3 ... ok
+test count_vec::vec_0_1_expects_complex_count_2 ... ok
 test create_path::_cargo_toml_expects_complex_path_path ... ok
 test create_path::_src_lib_rs_expects_complex_path_file ... ok
 test create_path::long_dir ... ok
 test create_path::short_dir ... ok
+test empty::vec_0_expects_complex_empty ... FAILED
+test empty::vec_expects_complex_empty ... ok
 test in_parens::_2_0_expects_complex_eq_2_0 ... ok
+test len_byte_str::b_ab_expects_complex_len_2 ... ok
+test len_byte_str::b_abc_expects_complex_len_3 ... ok
+test len_str::_ab_expects_complex_len_2 ... ok
+test len_str::_abc_expects_complex_len_3 ... ok
+test len_string::_ab_expects_complex_len_2 ... ok
+test len_string::_abc_expects_complex_len_3 ... ok
+test len_vec::vec_0_1_3_expects_complex_len_3 ... ok
+test len_vec::vec_0_1_expects_complex_len_2 ... ok
 test not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
 test not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_5 ... ok
@@ -43,4 +62,5 @@ test not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_in_order_3_2_ 
 test not_path::_cargo_toml_parse_unwrap_expects_complex_not_path_dir ... ok
 test not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path_path ... ok
 test not_path::_src_parse_unwrap_expects_complex_not_path_file ... ok
-test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 53 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+thread 'empty::vec_0_expects_complex_empty' panicked at 'assertion failed: _result.is_empty()', src/lib.rs:115:1

--- a/tests/snapshots/rust-nightly/acceptance__cases_support_complex_assertions.snap
+++ b/tests/snapshots/rust-nightly/acceptance__cases_support_complex_assertions.snap
@@ -1,9 +1,13 @@
 ---
 source: tests/acceptance_tests.rs
-assertion_line: 100
+assertion_line: 107
 expression: output
 ---
-running 39 tests
+    empty::vec_0_expects_complex_empty
+---- empty::vec_0_expects_complex_empty stdout ----
+failures:
+failures:
+running 54 tests
 test combinators::_0_3_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
 test combinators::_0_7_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
 test combinators::_1_0_expects_complex_gt_0_0_and_lt_5_0 ... ok
@@ -31,11 +35,26 @@ test complex_tests::lt1 ... ok
 test complex_tests::lt2 ... ok
 test contains_tests::vec_1_2_3_4_expects_complex_contains_1 ... ok
 test contains_tests::vec_1_2_3_4_expects_complex_contains_in_order_3_4_ ... ok
+test count_general::_abcd_chars_expects_complex_count_4 ... ok
+test count_general::std_iter_once_2_expects_complex_count_1 ... ok
+test count_general::vec_0_1_3_expects_complex_count_3 ... ok
+test count_vec::vec_0_1_3_expects_complex_count_3 ... ok
+test count_vec::vec_0_1_expects_complex_count_2 ... ok
 test create_path::_cargo_toml_expects_complex_path_path ... ok
 test create_path::_src_lib_rs_expects_complex_path_file ... ok
 test create_path::long_dir ... ok
 test create_path::short_dir ... ok
+test empty::vec_0_expects_complex_empty ... FAILED
+test empty::vec_expects_complex_empty ... ok
 test in_parens::_2_0_expects_complex_eq_2_0 ... ok
+test len_byte_str::b_ab_expects_complex_len_2 ... ok
+test len_byte_str::b_abc_expects_complex_len_3 ... ok
+test len_str::_ab_expects_complex_len_2 ... ok
+test len_str::_abc_expects_complex_len_3 ... ok
+test len_string::_ab_expects_complex_len_2 ... ok
+test len_string::_abc_expects_complex_len_3 ... ok
+test len_vec::vec_0_1_3_expects_complex_len_3 ... ok
+test len_vec::vec_0_1_expects_complex_len_2 ... ok
 test not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
 test not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_5 ... ok
@@ -43,4 +62,5 @@ test not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_in_order_3_2_ 
 test not_path::_cargo_toml_parse_unwrap_expects_complex_not_path_dir ... ok
 test not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path_path ... ok
 test not_path::_src_parse_unwrap_expects_complex_not_path_file ... ok
-test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+test result: FAILED. 53 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+thread 'empty::vec_0_expects_complex_empty' panicked at 'assertion failed: _result.is_empty()', src/lib.rs:115:1

--- a/tests/snapshots/rust-stable/acceptance__cases_support_complex_assertions.snap
+++ b/tests/snapshots/rust-stable/acceptance__cases_support_complex_assertions.snap
@@ -1,9 +1,13 @@
 ---
 source: tests/acceptance_tests.rs
-assertion_line: 100
+assertion_line: 107
 expression: output
 ---
-running 39 tests
+    empty::vec_0_expects_complex_empty
+---- empty::vec_0_expects_complex_empty stdout ----
+failures:
+failures:
+running 54 tests
 test combinators::_0_3_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
 test combinators::_0_7_expects_complex_gt_0_0_and_lt_1_0_or_gt_1_2 ... ok
 test combinators::_1_0_expects_complex_gt_0_0_and_lt_5_0 ... ok
@@ -31,11 +35,26 @@ test complex_tests::lt1 ... ok
 test complex_tests::lt2 ... ok
 test contains_tests::vec_1_2_3_4_expects_complex_contains_1 ... ok
 test contains_tests::vec_1_2_3_4_expects_complex_contains_in_order_3_4_ ... ok
+test count_general::_abcd_chars_expects_complex_count_4 ... ok
+test count_general::std_iter_once_2_expects_complex_count_1 ... ok
+test count_general::vec_0_1_3_expects_complex_count_3 ... ok
+test count_vec::vec_0_1_3_expects_complex_count_3 ... ok
+test count_vec::vec_0_1_expects_complex_count_2 ... ok
 test create_path::_cargo_toml_expects_complex_path_path ... ok
 test create_path::_src_lib_rs_expects_complex_path_file ... ok
 test create_path::long_dir ... ok
 test create_path::short_dir ... ok
+test empty::vec_0_expects_complex_empty ... FAILED
+test empty::vec_expects_complex_empty ... ok
 test in_parens::_2_0_expects_complex_eq_2_0 ... ok
+test len_byte_str::b_ab_expects_complex_len_2 ... ok
+test len_byte_str::b_abc_expects_complex_len_3 ... ok
+test len_str::_ab_expects_complex_len_2 ... ok
+test len_str::_abc_expects_complex_len_3 ... ok
+test len_string::_ab_expects_complex_len_2 ... ok
+test len_string::_abc_expects_complex_len_3 ... ok
+test len_vec::vec_0_1_3_expects_complex_len_3 ... ok
+test len_vec::vec_0_1_expects_complex_len_2 ... ok
 test not_complex::_1_0_expects_complex_not_almost_2_1_p_0_01 ... ok
 test not_complex::_1_0_expects_complex_not_eq_2_5 ... ok
 test not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_5 ... ok
@@ -43,4 +62,5 @@ test not_contains_tests::vec_1_2_3_4_expects_complex_not_contains_in_order_3_2_ 
 test not_path::_cargo_toml_parse_unwrap_expects_complex_not_path_dir ... ok
 test not_path::_cargo_yaml_parse_unwrap_expects_complex_not_path_path ... ok
 test not_path::_src_parse_unwrap_expects_complex_not_path_file ... ok
-test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+test result: FAILED. 53 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+thread 'empty::vec_0_expects_complex_empty' panicked at 'assertion failed: _result.is_empty()', src/lib.rs:115:1


### PR DESCRIPTION
* add complex `len` and `has_length` keywords to assert collections that provide .len() method
* add complex `count` and `has_count` keywords to assert collections that implement IntoIterator trait
* add complex `empty` keyword to assert whether collection is empty via `is_empty()` associated method