### PR TITLE
Allow ignore reason

### DIFF
--- a/crates/test-case-macros/src/modifier.rs
+++ b/crates/test-case-macros/src/modifier.rs
@@ -15,7 +15,7 @@ pub enum Modifier {
 impl Parse for Modifier {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if input.peek(kw::inconclusive) {
-            let _: kw::inconclusive = input.parse::<kw::inconclusive>()?;
+            let _: kw::inconclusive = input.parse()?;
             Ok(Self::Inconclusive)
         } else if input.peek(kw::ignore) {
             let _: kw::ignore = input.parse()?;

--- a/crates/test-case-macros/src/modifier.rs
+++ b/crates/test-case-macros/src/modifier.rs
@@ -1,25 +1,38 @@
 use std::collections::HashSet;
+use std::fmt::{Debug, Formatter};
 use syn::parse::{Parse, ParseStream};
-use syn::{parse_quote, Attribute};
+use syn::token::Bracket;
+use syn::{bracketed, parse_quote, Attribute, LitStr};
 
 mod kw {
     syn::custom_keyword!(inconclusive);
     syn::custom_keyword!(ignore);
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash)]
 pub enum Modifier {
     Inconclusive,
+    InconclusiveWithReason(LitStr),
+}
+
+impl Debug for Modifier {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Modifier::Inconclusive | Modifier::InconclusiveWithReason(_) => {
+                write!(f, "inconclusive")
+            }
+        }
+    }
 }
 
 impl Parse for Modifier {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if input.peek(kw::inconclusive) {
             let _: kw::inconclusive = input.parse()?;
-            Ok(Self::Inconclusive)
+            Self::parse_inconclusive(input)
         } else if input.peek(kw::ignore) {
             let _: kw::ignore = input.parse()?;
-            Ok(Self::Inconclusive)
+            Self::parse_inconclusive(input)
         } else {
             Err(syn::Error::new(input.span(), "unknown modifier keyword"))
         }
@@ -27,9 +40,21 @@ impl Parse for Modifier {
 }
 
 impl Modifier {
+    pub fn parse_inconclusive(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(Bracket) {
+            let content;
+            let _: Bracket = bracketed!(content in input);
+            let reason: LitStr = content.parse()?;
+            Ok(Self::InconclusiveWithReason(reason))
+        } else {
+            Ok(Self::Inconclusive)
+        }
+    }
+
     pub fn attribute(&self) -> Attribute {
         match self {
             Modifier::Inconclusive => parse_quote! { #[ignore] },
+            Modifier::InconclusiveWithReason(r) => parse_quote! { #[ignore = #r] },
         }
     }
 }

--- a/tests/acceptance_cases/cases_can_be_ignored/src/lib.rs
+++ b/tests/acceptance_cases/cases_can_be_ignored/src/lib.rs
@@ -14,3 +14,10 @@ fn inconclusives(_: ()) {
 fn ignore_void(input: u8) {
     assert_eq!(input, 1)
 }
+
+#[test_case(() => inconclusive["reason but no comment"] ())]
+#[test_case(() => inconclusive["reason and comment"] (); "test is not run")]
+#[test_case(() => ignore["reason and comment"] (); "ignore keyword")]
+fn descriptions(_: ()) {
+    unreachable!()
+}

--- a/tests/snapshots/rust-1.49.0/acceptance__cases_can_be_ignored.snap
+++ b/tests/snapshots/rust-1.49.0/acceptance__cases_can_be_ignored.snap
@@ -1,13 +1,15 @@
 ---
 source: tests/acceptance_tests.rs
-assertion_line: 88
 expression: output
 ---
-running 6 tests
+running 9 tests
+test descriptions::_expects_inconclusive_ ... ignored
+test descriptions::ignore_keyword ... ignored
+test descriptions::test_is_not_run ... ignored
 test ignore_void::_1_expects_inconclusiveempty ... ignored
 test ignore_void::_2_expects_inconclusiveempty ... ignored
 test inconclusives::_expects_inconclusive_ ... ignored
 test inconclusives::ignore_keyword ... ignored
 test inconclusives::inconclusive_test ... ignored
 test inconclusives::test_is_not_ran ... ignored
-test result: ok. 0 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out
+test result: ok. 0 passed; 0 failed; 9 ignored; 0 measured; 0 filtered out

--- a/tests/snapshots/rust-nightly/acceptance__cases_can_be_ignored.snap
+++ b/tests/snapshots/rust-nightly/acceptance__cases_can_be_ignored.snap
@@ -1,13 +1,15 @@
 ---
 source: tests/acceptance_tests.rs
-assertion_line: 88
 expression: output
 ---
-running 6 tests
+running 9 tests
+test descriptions::_expects_inconclusive_ ... ignored, reason but no comment
+test descriptions::ignore_keyword ... ignored, reason and comment
+test descriptions::test_is_not_run ... ignored, reason and comment
 test ignore_void::_1_expects_inconclusiveempty ... ignored
 test ignore_void::_2_expects_inconclusiveempty ... ignored
 test inconclusives::_expects_inconclusive_ ... ignored
 test inconclusives::ignore_keyword ... ignored
 test inconclusives::inconclusive_test ... ignored
 test inconclusives::test_is_not_ran ... ignored
-test result: ok. 0 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.00s
+test result: ok. 0 passed; 0 failed; 9 ignored; 0 measured; 0 filtered out; finished in 0.00s

--- a/tests/snapshots/rust-stable/acceptance__cases_can_be_ignored.snap
+++ b/tests/snapshots/rust-stable/acceptance__cases_can_be_ignored.snap
@@ -1,13 +1,15 @@
 ---
 source: tests/acceptance_tests.rs
-assertion_line: 88
 expression: output
 ---
-running 6 tests
+running 9 tests
+test descriptions::_expects_inconclusive_ ... ignored, reason but no comment
+test descriptions::ignore_keyword ... ignored, reason and comment
+test descriptions::test_is_not_run ... ignored, reason and comment
 test ignore_void::_1_expects_inconclusiveempty ... ignored
 test ignore_void::_2_expects_inconclusiveempty ... ignored
 test inconclusives::_expects_inconclusive_ ... ignored
 test inconclusives::ignore_keyword ... ignored
 test inconclusives::inconclusive_test ... ignored
 test inconclusives::test_is_not_ran ... ignored
-test result: ok. 0 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.00s
+test result: ok. 0 passed; 0 failed; 9 ignored; 0 measured; 0 filtered out; finished in 0.00s


### PR DESCRIPTION
Allow users to specify a reason why a test is `inconclusive`/`ignored` and translate into `#[ignore = "Reason"]`. This will be picked up by `cargo test` from 1.61.0 onward and displayed in the output. e.g.
```rust

#[test_case(() => inconclusive["reason but no comment"] ())]
#[test_case(() => inconclusive["reason and comment"] (); "test is not run")]
#[test_case(() => ignore["reason and comment"] (); "ignore keyword")]
fn descriptions(_: ()) {
    unreachable!()
}
```
Results in:
```
test descriptions::_expects_inconclusive_ ... ignored, reason but no comment
test descriptions::ignore_keyword ... ignored, reason and comment
test descriptions::test_is_not_run ... ignored, reason and comment
```

Fixes #102.