### PR TITLE
Set MSRV in `Cargo.toml` to 1.58.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,3 +73,24 @@ jobs:
           SNAPSHOT_DIR: rust-${{ matrix.toolchain }}
         with:
           command: test
+
+  msrv-build:
+    name: Build crate with documented MSRV
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Rust MSRV version
+        run: scripts/force-msrv-toolchain.sh
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 .idea
 
 *.new
+
+# Ignore toolchain installed by script
+rust-toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "test-case"
 version       = "3.0.0"
-edition       = "2018"
+edition       = "2021"
 authors       = ["Marcin Sas-Szymanski <marcin.sas-szymanski@anixe.pl>", "Wojciech Polak <frondeus@gmail.com>", "Łukasz Biel <lukasz.p.biel@gmail.com>"]
 description   = "Provides #[test_case(...)] procedural macro attribute for generating parametrized test cases easily"
 keywords      = ["test", "case", "tests", "unit", "testing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license       = "MIT"
 repository    = "https://github.com/frondeus/test-case"
 documentation = "https://docs.rs/test-case"
 exclude       = ["tests/snapshots/**/*"]
+rust-version  = "1.58.1"
 
 [features]
 with-regex = ["regex", "test-case-macros/with-regex"]

--- a/crates/test-case-core/Cargo.toml
+++ b/crates/test-case-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "test-case-core"
 version       = "3.0.0"
-edition       = "2018"
+edition       = "2021"
 authors       = ["Marcin Sas-Szymanski <marcin.sas-szymanski@anixe.pl>", "Wojciech Polak <frondeus@gmail.com>", "Łukasz Biel <lukasz.p.biel@gmail.com>"]
 description   = "Provides core functionality for parsing #[test_case(...)] procedural macro attribute for generating parametrized test cases easily"
 keywords      = ["test", "case", "tests", "unit", "testing"]

--- a/crates/test-case-macros/Cargo.toml
+++ b/crates/test-case-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "test-case-macros"
 version       = "3.0.0"
-edition       = "2018"
+edition       = "2021"
 authors       = ["Marcin Sas-Szymanski <marcin.sas-szymanski@anixe.pl>", "Wojciech Polak <frondeus@gmail.com>", "Łukasz Biel <lukasz.p.biel@gmail.com>"]
 description   = "Provides #[test_case(...)] procedural macro attribute for generating parametrized test cases easily"
 keywords      = ["test", "case", "tests", "unit", "testing"]

--- a/scripts/force-msrv-toolchain.sh
+++ b/scripts/force-msrv-toolchain.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+#
+# Force the use of the MSRV toolchain (for use with the CI).
+# Since action-rs/toolchain@v1 uses rustup 1.21.x, only the
+# toolchain name can be given in the file.
+#
+# If you call this script in your working directory, do not
+# forget that it will create a "rust-toolchain" file there.
+
+set -e
+
+root=$(dirname "$0")/..
+
+version=$(sed -ne 's/rust-version *= *"\(.*\)"/\1/p' "$root"/Cargo.toml)
+echo $version > "$root"/rust-toolchain
+echo "Rust $version installed as the forced toolchain"

--- a/tests/acceptance_cases/cases_can_be_declared_on_async_methods/Cargo.toml
+++ b/tests/acceptance_cases/cases_can_be_declared_on_async_methods/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async_tests"
 version = "0.1.0"
 authors = ["Łukasz Biel <lukasz.p.biel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "async"

--- a/tests/acceptance_cases/cases_can_be_declared_on_non_test_items/Cargo.toml
+++ b/tests/acceptance_cases/cases_can_be_declared_on_non_test_items/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_can_be_declared_on_non_test_items"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "cases_can_be_declared_on_non_test_items"

--- a/tests/acceptance_cases/cases_can_be_ignored/Cargo.toml
+++ b/tests/acceptance_cases/cases_can_be_ignored/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_can_be_ignored"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/cases_can_panic/Cargo.toml
+++ b/tests/acceptance_cases/cases_can_panic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_can_panic"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/cases_can_return_result/Cargo.toml
+++ b/tests/acceptance_cases/cases_can_return_result/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_can_return_result"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "cases_can_return_result"

--- a/tests/acceptance_cases/cases_can_use_regex/Cargo.toml
+++ b/tests/acceptance_cases/cases_can_use_regex/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_can_use_regex"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/cases_support_basic_features/Cargo.toml
+++ b/tests/acceptance_cases/cases_support_basic_features/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cases_support_basic_features"
 version = "0.1.0"
 authors = ["Łukasz Biel <lukasz.p.biel@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "cases_support_basic_features"

--- a/tests/acceptance_cases/cases_support_complex_assertions/Cargo.toml
+++ b/tests/acceptance_cases/cases_support_complex_assertions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_support_complex_assertions"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/cases_support_generics/Cargo.toml
+++ b/tests/acceptance_cases/cases_support_generics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_support_generics"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/cases_support_keyword_using/Cargo.toml
+++ b/tests/acceptance_cases/cases_support_keyword_using/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_support_keyword_using"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/cases_support_keyword_with/Cargo.toml
+++ b/tests/acceptance_cases/cases_support_keyword_with/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_support_keyword_with"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/cases_support_multiple_calling_methods/Cargo.toml
+++ b/tests/acceptance_cases/cases_support_multiple_calling_methods/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_support_multiple_calling_methods"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/cases_support_pattern_matching/Cargo.toml
+++ b/tests/acceptance_cases/cases_support_pattern_matching/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cases_support_pattern_matching"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/acceptance_cases/features_produce_human_readable_errors/Cargo.toml
+++ b/tests/acceptance_cases/features_produce_human_readable_errors/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "features_produce_human_readable_errors"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Setting the MSRV in `Cargo.toml` helps various tools to check if they can use a particular version of a crate.

The current lowest compiler with wich test-case currently builds is 1.58, this is the version I used in `Cargo.toml`. However, note that to run succesfully tests require a recent version.

Since 1.58.1 is a 2021 edition compiler, I bumped the edition to 2021 as well.

I've added a Github Actions job to check that the crate can be built (but not tested) with the documented MSRV. 

I suggest later moving to https://github.com/dtolnay/rust-toolchain which supports using toolchains such as "stable minus 2 releases" which seems to meet test-case's published goals.