### PR TITLE
retain allow attribute in test_case macro

### DIFF
--- a/crates/test-case-macros/src/lib.rs
+++ b/crates/test-case-macros/src/lib.rs
@@ -72,7 +72,12 @@ fn render_test_cases(test_cases: &[(TestCase, Span2)], mut item: ItemFn) -> Toke
     let mod_name = item.sig.ident.clone();
 
     // We don't want any external crate to alter main fn code, we are passing attributes to each sub-function anyway
-    item.attrs.clear();
+    item.attrs.retain(|attr| {
+        attr.path
+            .get_ident()
+            .map(|ident| ident == "allow")
+            .unwrap_or(false)
+    });
 
     let output = quote! {
         #[allow(unused_attributes)]

--- a/tests/acceptance_cases/allow_stays_on_fn/Cargo.toml
+++ b/tests/acceptance_cases/allow_stays_on_fn/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "allow_stays_on_fn"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "allow_stays_on_fn"
+path = "src/lib.rs"
+doctest = false
+
+[dependencies]
+test-case = { path = "../../../" }
+
+[workspace]

--- a/tests/acceptance_cases/allow_stays_on_fn/src/lib.rs
+++ b/tests/acceptance_cases/allow_stays_on_fn/src/lib.rs
@@ -1,0 +1,7 @@
+#![deny(unused_variables)]
+
+use test_case::test_case;
+
+#[test_case(42)]
+#[allow(unused_variables)]
+fn allow_stays_on_fn(value: u32) {}

--- a/tests/acceptance_tests.rs
+++ b/tests/acceptance_tests.rs
@@ -142,3 +142,8 @@ fn cases_can_use_regex() {
 fn features_produce_human_readable_errors() {
     run_acceptance_test!("features_produce_human_readable_errors")
 }
+
+#[test]
+fn allow_stays_on_fn() {
+    run_acceptance_test!("allow_stays_on_fn")
+}

--- a/tests/snapshots/rust-nightly/acceptance__allow_stays_on_fn.snap
+++ b/tests/snapshots/rust-nightly/acceptance__allow_stays_on_fn.snap
@@ -1,0 +1,7 @@
+---
+source: tests/acceptance_tests.rs
+expression: output
+---
+running 1 test
+test allow_stays_on_fn::_42_expects ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

--- a/tests/snapshots/rust-stable/acceptance__allow_stays_on_fn.snap
+++ b/tests/snapshots/rust-stable/acceptance__allow_stays_on_fn.snap
@@ -1,0 +1,7 @@
+---
+source: tests/acceptance_tests.rs
+expression: output
+---
+running 1 test
+test allow_stays_on_fn::_42_expects ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


### PR DESCRIPTION
Ran into an issue where a function was triggering `clippy::too_many_lines` and test_case was removing the `#[allow(clippy::too_many_lines)]`.