### PR TITLE
Fix test_matrix example that does not compile in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ mod tests {
     use test_case::test_matrix;
 
     #[test_matrix(
-        [-2, 2],
-        [-4, 4]
+        [4, 6, 8],
+        [1, 3, 5]
     )]
     fn multiplication_tests(x: i8, y: i8) {
-        let actual = (x * y).abs();
+        let product = x * y;
 
-        assert_eq!(8, actual)
+        assert_eq!(0, product % 2)
     }
 }
 ```


### PR DESCRIPTION
The current example in the README does not compile, I thought I'd adjust to an example that does :)

```
[~/Documents/code/test-case-example] nick@cubert$ cargo t
   Compiling tmp v0.1.0 (/home/nick/Documents/code/test-case-example)
error[E0428]: the name `_2_4_expects` is defined multiple times
  --> src/lib.rs:9:5
   |
9  | /     #[test_matrix(
10 | |         [-2, 2],
11 | |         [-4, 4]
12 | |     )]
   | |______^ `_2_4_expects` redefined here
   |
   = note: `_2_4_expects` must be defined only once in the value namespace of this module
   = note: this error originates in the attribute macro `test_matrix` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0428`.
error: could not compile `tmp` (lib test) due to previous error
```