### PR TITLE
deps: disable proc-macro-error default features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - develop
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   validate:

--- a/crates/test-case-core/Cargo.toml
+++ b/crates/test-case-core/Cargo.toml
@@ -24,6 +24,6 @@ path       = "src/lib.rs"
 [dependencies]
 cfg-if           = "1.0"
 proc-macro2      = { version = "1.0", features = [] }
-proc-macro-error = "1.0"
+proc-macro-error = { version = "1.0", default-features = false }
 quote            = "1.0"
 syn              = { version = "2.0", features = ["full", "extra-traits"] }

--- a/crates/test-case-macros/Cargo.toml
+++ b/crates/test-case-macros/Cargo.toml
@@ -24,7 +24,7 @@ path       = "src/lib.rs"
 
 [dependencies]
 proc-macro2      = { version = "1.0", features = [] }
-proc-macro-error = "1.0"
+proc-macro-error = { version = "1.0", default-features = false }
 quote            = "1.0"
 syn              = { version = "2.0", features = ["full", "extra-traits", "parsing"] }
 test-case-core   = { version = "3.2.1", path = "../test-case-core", default-features = false }


### PR DESCRIPTION
proc-macro-error has an optional dependency on syn@1 whereas much of the
ecosystem has migrated to syn@2, resulting in dependents of test-case
having to compile syn twice. This avoids that by removing the optional
dependency.
