### PR TITLE
Remove proc-macro2-diagnostics dependency

### DIFF
--- a/crates/test-case-core/Cargo.toml
+++ b/crates/test-case-core/Cargo.toml
@@ -22,8 +22,7 @@ doctest    = false
 path       = "src/lib.rs"
 
 [dependencies]
-cfg-if                  = "1.0"
-proc-macro2             = { version = "1.0", features = [] }
-proc-macro2-diagnostics = "0.10"
-quote                   = "1.0"
-syn                     = { version = "2.0", features = ["full", "extra-traits"] }
+cfg-if      = "1.0"
+proc-macro2 = { version = "1.0", features = [] }
+quote       = "1.0"
+syn         = { version = "2.0", features = ["full", "extra-traits"] }

--- a/crates/test-case-core/src/complex_expr.rs
+++ b/crates/test-case-core/src/complex_expr.rs
@@ -451,11 +451,8 @@ fn regex_assertion(expected_regex: &Expr) -> TokenStream {
 fn not_assertion(not: &ComplexTestCase) -> TokenStream {
     match not {
         ComplexTestCase::Not(_) => {
-            use proc_macro2_diagnostics::SpanDiagnosticExt as _;
-
-            Span::call_site()
-                .error("multiple negations on single item are forbidden")
-                .emit_as_expr_tokens()
+            let msg = "multiple negations on single item are forbidden";
+            syn::Error::new(Span::call_site(), msg).into_compile_error()
         }
         ComplexTestCase::And(cases) => negate(and_assertion(cases)),
         ComplexTestCase::Or(cases) => negate(or_assertion(cases)),


### PR DESCRIPTION
The code using proc-macro2-diagnostics produces worse/spurious diagnostics on both stable and nightly compilers. Example:

```rust
use test_case::test_case;

#[test_case(1 => is not not eq 1 ; "repro")]
fn id(input: i32) -> i32 {
    input
}
```

**Before:**

```console
$ cargo +nightly test

error: multiple negations on single item are forbidden
 --> src/main.rs:3:1
  |
3 | #[test_case(1 => is not not eq 1 ; "repro")]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the attribute macro `test_case` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
 --> src/main.rs:3:45
  |
3 | #[test_case(1 => is not not eq 1 ; "repro")]
  | --------------------------------------------^ expected `bool`, found `()`
  | |
  | implicitly returns `()` as its body has no tail or `return` expression
  |
  = note: this error originates in the attribute macro `test_case` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0308`.
```

```console
$ cargo +stable test

error: multiple negations on single item are forbidden
 --> src/main.rs:3:1
  |
3 | #[test_case(1 => is not not eq 1 ; "repro")]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the attribute macro `test_case` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
 --> src/main.rs:3:1
  |
3 | #[test_case(1 => is not not eq 1 ; "repro")]
  | ^-------------------------------------------
  | |
  | expected `bool`, found `()`
  | implicitly returns `()` as its body has no tail or `return` expression
  |
  = note: this error originates in the attribute macro `test_case` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0308`.
```

**After:**

```console
$ cargo test  # (same on both)

error: multiple negations on single item are forbidden
 --> src/main.rs:3:1
  |
3 | #[test_case(1 => is not not eq 1 ; "repro")]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the attribute macro `test_case` (in Nightly builds, run with -Z macro-backtrace for more info)
```