### PR TITLE
feat: Invert the left and right output for simple test cases

### DIFF
--- a/crates/test-case-core/src/expr.rs
+++ b/crates/test-case-core/src/expr.rs
@@ -119,7 +119,7 @@ impl Display for TestCaseResult {
 impl TestCaseExpression {
     pub fn assertion(&self) -> TokenStream2 {
         match &self.result {
-            TestCaseResult::Simple(expr) => parse_quote! { assert_eq!(#expr, _result) },
+            TestCaseResult::Simple(expr) => parse_quote! { assert_eq!(_result, #expr) },
             TestCaseResult::Matching(pat, guard) => {
                 let pat_str = pat.to_token_stream().to_string();
 

--- a/tests/acceptance_cases/cases_can_panic/src/lib.rs
+++ b/tests/acceptance_cases/cases_can_panic/src/lib.rs
@@ -26,7 +26,11 @@ fn panics_without_value(_: ()) {
 }
 
 #[test_case(2, 2 => 2 + 3)]
-#[should_panic(expected = "assertion failed: `(left == right)`")]
+#[should_panic(expected = "\
+assertion `left == right` failed
+  left: 4
+ right: 5\
+")]
 fn result_which_panics(x: u32, y: u32) -> u32 {
     x + y
 }

--- a/tests/snapshots/rust-nightly/acceptance__cases_can_panic.snap
+++ b/tests/snapshots/rust-nightly/acceptance__cases_can_panic.snap
@@ -7,7 +7,6 @@ test panicking::_expects_panicking_some_it_has_to_panic_ - should panic ... ok
 test panicking::_expects_panicking_some_this_should_fail_ - should panic ... FAILED
 test panics_without_value::_expects_panicking_none - should panic ... ok
 test pattern_matching_result_fails::simpleenum_var1_expects_matching_simpleenum_var2_ - should panic ... ok
-test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
-test result_which_panics::_2_2_expects_2_3 - should panic ... FAILED
+test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+test result_which_panics::_2_2_expects_2_3 - should panic ... ok
 thread 'panicking::_expects_panicking_some_this_should_fail_' panicked at src/lib.rs:20:5:
-thread 'result_which_panics::_2_2_expects_2_3' panicked at src/lib.rs:28:1:

--- a/tests/snapshots/rust-nightly/acceptance__features_produce_human_readable_errors.snap
+++ b/tests/snapshots/rust-nightly/acceptance__features_produce_human_readable_errors.snap
@@ -3,4 +3,4 @@ source: tests/acceptance_tests.rs
 expression: output
 ---
 error: 'with-regex' feature is required to use 'matches-regex' keyword
-error: could not compile `features_produce_human_readable_errors` (lib test) due to previous error
+error: could not compile `features_produce_human_readable_errors` (lib test) due to 1 previous error

--- a/tests/snapshots/rust-stable/acceptance__cases_can_panic.snap
+++ b/tests/snapshots/rust-stable/acceptance__cases_can_panic.snap
@@ -7,7 +7,6 @@ test panicking::_expects_panicking_some_it_has_to_panic_ - should panic ... ok
 test panicking::_expects_panicking_some_this_should_fail_ - should panic ... FAILED
 test panics_without_value::_expects_panicking_none - should panic ... ok
 test pattern_matching_result_fails::simpleenum_var1_expects_matching_simpleenum_var2_ - should panic ... ok
-test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
-test result_which_panics::_2_2_expects_2_3 - should panic ... FAILED
+test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+test result_which_panics::_2_2_expects_2_3 - should panic ... ok
 thread 'panicking::_expects_panicking_some_this_should_fail_' panicked at src/lib.rs:20:5:
-thread 'result_which_panics::_2_2_expects_2_3' panicked at src/lib.rs:28:1:


### PR DESCRIPTION
Now the right side is the 'expected' one, and the left side is the 'input'. Example:

```rust
 #[test_case(2, 2 => 2 + 3)]
 fn result_which_panics(x: u32, y: u32) -> u32 {
     x + y
 }
```

Previously, the output was:

```
 Left:  5
 Right: 4
```

Now, it is:

```
 Left:  4
 Right: 5
```

Refs: #125