### PR TITLE
fix: improve compatibility among test proc macros

### DIFF
--- a/crates/test-case-macros/src/lib.rs
+++ b/crates/test-case-macros/src/lib.rs
@@ -110,7 +110,7 @@ fn expand_additional_test_case_macros(item: &mut ItemFn) -> syn::Result<Vec<(Tes
     }
 
     for i in attrs_to_remove.into_iter().rev() {
-        item.attrs.swap_remove(i);
+        item.attrs.remove(i);
     }
 
     Ok(additional_cases)

--- a/tests/acceptance_tests.rs
+++ b/tests/acceptance_tests.rs
@@ -22,7 +22,7 @@ macro_rules! run_acceptance_test {
 
             let output = sanitize_lines(output);
 
-            insta::assert_display_snapshot!(output);
+            insta::assert_snapshot!(output);
         })
     };
     ($case_name:expr) => {

--- a/tests/snapshots/rust-nightly/acceptance__matrices_compilation_errors.snap
+++ b/tests/snapshots/rust-nightly/acceptance__matrices_compilation_errors.snap
@@ -5,6 +5,6 @@ expression: output
 error: All literal values must be of the same type
 error: Range bounds can only be an integer literal
 error: Unbounded ranges are not supported
-error: could not compile `matrices_compilation_errors` (lib test) due to 5 previous errors
+error: could not compile `matrices_compilation_errors` (lib test) due to 5 previous errors; 1 warning emitted
 error: number too large to fit in target type
 error[E0308]: mismatched types

--- a/tests/snapshots/rust-stable/acceptance__features_produce_human_readable_errors.snap
+++ b/tests/snapshots/rust-stable/acceptance__features_produce_human_readable_errors.snap
@@ -3,4 +3,4 @@ source: tests/acceptance_tests.rs
 expression: output
 ---
 error: 'with-regex' feature is required to use 'matches-regex' keyword
-error: could not compile `features_produce_human_readable_errors` (lib test) due to previous error
+error: could not compile `features_produce_human_readable_errors` (lib test) due to 1 previous error

--- a/tests/snapshots/rust-stable/acceptance__matrices_compilation_errors.snap
+++ b/tests/snapshots/rust-stable/acceptance__matrices_compilation_errors.snap
@@ -5,6 +5,6 @@ expression: output
 error: All literal values must be of the same type
 error: Range bounds can only be an integer literal
 error: Unbounded ranges are not supported
-error: could not compile `matrices_compilation_errors` (lib test) due to 5 previous errors
+error: could not compile `matrices_compilation_errors` (lib test) due to 5 previous errors; 1 warning emitted
 error: number too large to fit in target type
 error[E0308]: mismatched types


### PR DESCRIPTION
This pr proposes a generic mechanism among different test proc macros to avoid to generate multiple `[::core::prelude::v1::test]` on test method.

`proc_macro_attribute` function is fed with tokens after its attribute and no tokens before it.

Give the above, this pr proposes test proc macros to append newly generated macros after existing ones. This way, proc macros processed later can read all macros including generated and handwritten and make further decisions. Specifically, proc macros can append `#[::core::prelude::v1::test]` only if it does not exist.

Macros that transform test method signature can append `#[::core::prelude::v1::test]` directly without checking its existence once they generate valid signature for test method.

Closes #101.